### PR TITLE
Fix get_forum_last_post mistake

### DIFF
--- a/machina/apps/forum_permission/handler.py
+++ b/machina/apps/forum_permission/handler.py
@@ -64,10 +64,9 @@ class PermissionHandler(object):
             hidden_forums = self._get_hidden_forum_ids(forums, user)
 
         forums = forums.exclude(id__in=hidden_forums)
-        posts = Post.approved_objects.filter(topic__forum__in=forums).order_by('-created')
-        posts = list(posts)
+        posts = Post.approved_objects.filter(topic__forum__in=forums).order_by('-created')[:1]
 
-        if not posts:
+        if not len(posts):
             return None
         return posts[0]
 


### PR DESCRIPTION
Fetch only one post in PermissionHandler's get_forum_last_post function instead of all the posts for that forum.