### PR TITLE
Fixing migration error(for mariadb)

### DIFF
--- a/machina/apps/forum_conversation/migrations/0001_initial.py
+++ b/machina/apps/forum_conversation/migrations/0001_initial.py
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True, verbose_name='Creation date')),
                 ('updated', models.DateTimeField(auto_now=True, verbose_name='Update date')),
                 ('subject', models.CharField(max_length=255, verbose_name='Subject')),
-                ('slug', models.SlugField(max_length=300, verbose_name='Slug')),
+                ('slug', models.SlugField(max_length=255, verbose_name='Slug')),
                 ('type', models.PositiveSmallIntegerField(db_index=True, verbose_name='Topic type', choices=[(0, 'Default topic'), (1, 'Sticky'), (2, 'Announce')])),
                 ('status', models.PositiveIntegerField(db_index=True, verbose_name='Topic status', choices=[(0, 'Topic unlocked'), (1, 'Topic locked'), (2, 'Topic moved')])),
                 ('approved', models.BooleanField(default=True, verbose_name='Approved')),


### PR DESCRIPTION
Hi. I use MariaDB 10.0.22. When I tried install django-machina, i got this error:

`#1071 - Specified key was too long; max key length is 767 bytes`

I've tried change in DB 'innodb_large_prefix' parameter to ON, but it didn't help. 

I found only this solution. Hopefully it's true.