### PR TITLE
Adaptation Middleware to Django 1.10 requirements

### DIFF
--- a/machina/apps/forum_permission/middleware.py
+++ b/machina/apps/forum_permission/middleware.py
@@ -18,7 +18,10 @@ class ForumPermissionMiddleware(object):
     """
     anonymous_forum_key_session_id = '_anonymous_forum_key'
 
-    def process_request(self, request):
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+        
+    def __call__(self, request):
         if not request.user.is_authenticated():
             # Get the anonymous forum key and attaches it the AnonymousUser instance.
             anonymous_forum_key = request.session.get(self.anonymous_forum_key_session_id, None)
@@ -29,7 +32,9 @@ class ForumPermissionMiddleware(object):
             setattr(request.user, 'forum_key', anonymous_forum_key)
 
         request.forum_permission_handler = PermissionHandler()
-
+        response = self.get_response(request)
+        return response
+        
     def get_anonymous_forum_key(self):
         """
         Returns a random anonymous forum key.


### PR DESCRIPTION
Django-machina doesn't start with Django 1.10 due to new middleware style. I tried to adapt middleware to new requirements.
It works good now with Django 1.10, but I'm not sure about other versions and correctness of my code.