### PR TITLE
Fix translations for profile stats and verbose_name masking

### DIFF
--- a/example_projects/demo/src/demo_project/templates/forum_member/forum_profile_detail.html
+++ b/example_projects/demo/src/demo_project/templates/forum_member/forum_profile_detail.html
@@ -51,12 +51,14 @@
       						<div class="row">
       				            <div class="col-md-12 divider text-center">
       				                <div class="col-xs-12 col-sm-6 emphasis">
-      				                    <h2><strong>{{ profile.posts_count }}</strong></h2>
-      				                    <p><small>{% blocktrans count counter=profile.posts_count %}Post{% plural %}Posts{% endblocktrans %}</small></p>
+      				                    {% blocktrans count counter=profile.posts_count %}<h2><strong>{{ counter }}</strong></h2>
+      				                    <p><small>Post</small></p>{% plural %}<h2><strong>{{ counter }}</strong></h2>
+      				                    <p><small>Posts</small></p>{% endblocktrans %}
       				                </div>
       				                <div class="col-xs-12 col-sm-6 emphasis">
-      				                    <h2><strong>{{ topics_count }}</strong></h2>
-      				                    <p><small>{% blocktrans count counter=profile.posts_count %}Topic{% plural %}Topics{% endblocktrans %}</small></p>
+      				                    {% blocktrans count counter=topics_count %}<h2><strong>{{ counter }}</strong></h2>
+      				                    <p><small>Topic</small></p>{% plural %}<h2><strong>{{ counter }}</strong></h2>
+      				                    <p><small>Topics</small></p>{% endblocktrans %}
       				                </div>
       				            </div>
       			            </div>

--- a/machina/templates/machina/forum_member/forum_profile_detail.html
+++ b/machina/templates/machina/forum_member/forum_profile_detail.html
@@ -42,12 +42,14 @@
               <div class="row">
                 <div class="col-md-12 divider text-center">
                   <div class="col-xs-12 col-sm-6 emphasis">
-                    <h2><strong>{{ profile.posts_count }}</strong></h2>
-                    <p><small>{% blocktrans count counter=profile.posts_count %}Post{% plural %}Posts{% endblocktrans %}</small></p>
+                    {% blocktrans count counter=profile.posts_count %}<h2><strong>{{ counter }}</strong></h2>
+                    <p><small>Post</small></p>{% plural %}<h2><strong>{{ counter }}</strong></h2>
+                    <p><small>Posts</small></p>{% endblocktrans %}
                   </div>
                   <div class="col-xs-12 col-sm-6 emphasis">
-                    <h2><strong>{{ topics_count }}</strong></h2>
-                    <p><small>{% blocktrans count counter=profile.posts_count %}Topic{% plural %}Topics{% endblocktrans %}</small></p>
+                    {% blocktrans count counter=topics_count %}<h2><strong>{{ counter }}</strong></h2>
+                    <p><small>Topic</small></p>{% plural %}<h2><strong>{{ counter }}</strong></h2>
+                    <p><small>Topics</small></p>{% endblocktrans %}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Fix issue where an incorrectly written plural blocktrans caused the
verbose_name of Post and Topic to be untranslated by "masking" the msgid.

By including both the counter and the wrapping html in the blocktrans block the msgid is no longer the same as the verbose_name in the models, and it's now possible to translate into a language that requires the count to comes last.