### PR TITLE
Don't update poster field when editing posts.

### DIFF
--- a/machina/apps/forum_conversation/forms.py
+++ b/machina/apps/forum_conversation/forms.py
@@ -70,10 +70,12 @@ class PostForm(forms.ModelForm):
                 initial=self.topic.status == Topic.TOPIC_LOCKED)
 
     def clean(self):
-        if not self.user.is_anonymous():
-            self.instance.poster = self.user
-        else:
-            self.instance.anonymous_key = get_anonymous_user_forum_key(self.user)
+        if not self.instance.pk:
+            # Only set user on post creation
+            if not self.user.is_anonymous():
+                self.instance.poster = self.user
+            else:
+                self.instance.anonymous_key = get_anonymous_user_forum_key(self.user)
         return super(PostForm, self).clean()
 
     def save(self, commit=True):


### PR DESCRIPTION
Added check if the post does not have a pk (e.g. is new) before setting poster/anonymous-key, so that updating posts of others do not change the poster value.

Fix for https://github.com/ellmetha/django-machina/issues/39