### PR TITLE
Updating decrease_posts_count to prevent negative post count value

### DIFF
--- a/machina/apps/forum_member/receivers.py
+++ b/machina/apps/forum_member/receivers.py
@@ -55,6 +55,13 @@ def decrease_posts_count(sender, instance, **kwargs):
     related to the post's author is decreased.
     """
     try:
+        assert instance.approved is True
+    except AssertionError:
+        # If a post has not been approved, it has not been counted.
+        # So do not decrement count
+        return
+
+    try:
         assert instance.poster_id is not None
         poster = User.objects.get(pk=instance.poster_id)
     except AssertionError:
@@ -67,6 +74,5 @@ def decrease_posts_count(sender, instance, **kwargs):
         return
 
     profile, dummy = ForumProfile.objects.get_or_create(user=poster)
-    if profile.posts_count > 0:
-        profile.posts_count = F('posts_count') - 1
-        profile.save()
+    profile.posts_count = F('posts_count') - 1
+    profile.save()

--- a/machina/apps/forum_member/receivers.py
+++ b/machina/apps/forum_member/receivers.py
@@ -67,5 +67,6 @@ def decrease_posts_count(sender, instance, **kwargs):
         return
 
     profile, dummy = ForumProfile.objects.get_or_create(user=poster)
-    profile.posts_count = F('posts_count') - 1
-    profile.save()
+    if profile.posts_count > 0:
+        profile.posts_count = F('posts_count') - 1
+        profile.save()

--- a/machina/apps/forum_member/receivers.py
+++ b/machina/apps/forum_member/receivers.py
@@ -54,9 +54,7 @@ def decrease_posts_count(sender, instance, **kwargs):
     Receiver to handle the deletion of a forum posts: the posts count
     related to the post's author is decreased.
     """
-    try:
-        assert instance.approved is True
-    except AssertionError:
+    if not instance.approved:
         # If a post has not been approved, it has not been counted.
         # So do not decrement count
         return


### PR DESCRIPTION
If a member only has posts in moderation and none approved. There is
the possibility that if a moderator disapproves their posts, that the
member's post count could become negative.

If this happens, it will cause the check constraint on posts_count >= 0
to fail and an IntegrityError to be raised.

Adding a check that posts_count is greater than 0 before reducing it by one.
If post_count is 0, there is no need to reduce the count.

Thank you for contributing to django-machina! A list of simple rules is available on the online
documentation to help you contribute to this project: https://django-machina.readthedocs.org/en/stable/contributing.html.
Please review these guidelines before submitting your pull request!
