### PR TITLE
Fix post pagination issue #53

### DIFF
--- a/machina/apps/forum_conversation/views.py
+++ b/machina/apps/forum_conversation/views.py
@@ -57,7 +57,7 @@ class TopicView(PermissionRequiredMixin, ListView):
             try:
                 assert requested_post.isdigit()
                 post = topic.posts.get(pk=requested_post)
-                requested_page = (post.position // machina_settings.TOPIC_POSTS_NUMBER_PER_PAGE) + 1
+                requested_page = ((post.position - 1) // machina_settings.TOPIC_POSTS_NUMBER_PER_PAGE) + 1
                 request.GET = request.GET.copy()  # A QueryDict is immutable
                 request.GET.update({'page': requested_page})
             except (Post.DoesNotExist, AssertionError):

--- a/machina/apps/forum_conversation/views.py
+++ b/machina/apps/forum_conversation/views.py
@@ -57,7 +57,8 @@ class TopicView(PermissionRequiredMixin, ListView):
             try:
                 assert requested_post.isdigit()
                 post = topic.posts.get(pk=requested_post)
-                requested_page = ((post.position - 1) // machina_settings.TOPIC_POSTS_NUMBER_PER_PAGE) + 1
+                requested_page = ((post.position - 1) //
+                                  machina_settings.TOPIC_POSTS_NUMBER_PER_PAGE) + 1
                 request.GET = request.GET.copy()  # A QueryDict is immutable
                 request.GET.update({'page': requested_page})
             except (Post.DoesNotExist, AssertionError):

--- a/machina/templatetags/forum_conversation_tags.py
+++ b/machina/templatetags/forum_conversation_tags.py
@@ -36,7 +36,7 @@ def topic_pages_inline_list(topic):
         'topic': topic,
     }
 
-    pages_number = (topic.posts_count // machina_settings.TOPIC_POSTS_NUMBER_PER_PAGE) + 1
+    pages_number = ((topic.posts_count - 1) // machina_settings.TOPIC_POSTS_NUMBER_PER_PAGE) + 1
     if pages_number > 5:
         data_dict['first_pages'] = range(1, 5)
         data_dict['last_page'] = pages_number


### PR DESCRIPTION
Pagination for post position is incorrectly calculated in `machina/templatetags/forum_conversation_tags.py` and `machina/apps/forum_conversation/views.py`

The original code will calculate the page number as being one too high when the post_count or post.position is a multiple of TOPIC_POSTS_NUMBER_PER_PAGE.

For example, if the post number is 15 and the TOPIC_POSTS_NUMBER_PER_PAGE is 15, then the original code will calculate the page number according to the following code

    ( topic.posts_count // machina_settings.TOPIC_POSTS_NUMBER_PER_PAGE) + 1

This is equal to 15 // 15 + 1 = 2. The correct page number should be 1.

Decreasing the posts_count by 1 fixes that problem. 14 // 15 + 1 = 1
