### PR TITLE
Improvement in templates for posts with line breaks

### DIFF
--- a/machina/templates/machina/forum_conversation/post_create.html
+++ b/machina/templates/machina/forum_conversation/post_create.html
@@ -58,7 +58,7 @@
               {% endspaceless %}
               </small></p>
               <div class="post-content">
-                {{ post.content.rendered }}
+                {{ post.content.rendered|linebreaks }}
               </div>
               {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
             </div>

--- a/machina/templates/machina/forum_conversation/post_preview.html
+++ b/machina/templates/machina/forum_conversation/post_preview.html
@@ -10,7 +10,7 @@
                         <h4 class="subject">{% trans "Preview:" %}&nbsp;{{ post_form.subject.value }}</h4>
                         <hr />
                         <div class="post-content">
-                            {{ post_form.content.value|safe|rendered }}
+                            {{ post_form.content.value|safe|rendered|linebreaks }}
                         </div>
                         {% include "forum_conversation/forum_attachments/attachments_preview.html" %}
                     </div>

--- a/machina/templates/machina/forum_conversation/topic_detail.html
+++ b/machina/templates/machina/forum_conversation/topic_detail.html
@@ -61,7 +61,7 @@
                 </small>
               </p>
               <div class="post-content">
-                {{ post.content.rendered }}
+                {{ post.content.rendered|linebreaks }}
               </div>
               {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
               {% if post.enable_signature and post.poster.forum_profile.signature %}

--- a/machina/templates/machina/forum_feeds/topics_description.html
+++ b/machina/templates/machina/forum_feeds/topics_description.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 
-{{ obj.last_post.content.rendered|safe }}
+{{ obj.last_post.content.rendered|safe|linebreaks }}
 <br /><br />
 <i>{% trans "Posted by" %} {{ obj.poster.username }} - {{ obj.created }}</i>

--- a/machina/templates/machina/forum_member/forum_profile_detail.html
+++ b/machina/templates/machina/forum_member/forum_profile_detail.html
@@ -75,7 +75,7 @@
                   </small>
                 </p>
                 <div class="post-content">
-                  {{ post.content.rendered|truncatechars_html:160 }}
+                  {{ post.content.rendered|linebreaks|truncatechars_html:160 }}
                 </div>
               </div>
             </div>

--- a/machina/templates/machina/forum_member/user_posts_list.html
+++ b/machina/templates/machina/forum_member/user_posts_list.html
@@ -54,7 +54,7 @@
                   </small>
                 </p>
                 <div class="post-content">
-                  {{ post.content.rendered|truncatechars_html:250 }}
+                  {{ post.content.rendered|linebreaks|truncatechars_html:250 }}
                 </div>
             </div>
             <div class="col-md-2 post-sidebar">

--- a/machina/templates/machina/forum_moderation/moderation_queue/detail.html
+++ b/machina/templates/machina/forum_moderation/moderation_queue/detail.html
@@ -94,7 +94,7 @@
                                 </small>
                             </p>
                             <div class="post-content">
-                                {{ post.content.rendered }}
+                                {{ post.content.rendered|linebreaks }}
                             </div>
                             {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
                             {% if post.enable_signature and post.poster.forum_profile.signature %}

--- a/machina/templates/machina/forum_search/post_text.txt
+++ b/machina/templates/machina/forum_search/post_text.txt
@@ -1,2 +1,2 @@
 {{ object.subject }}
-{{ object.content.rendered }}
+{{ object.content.rendered|linebreaks }}


### PR DESCRIPTION
I detected a litte issue with posts containing a single line break. Single line breaks were not correctly displayed when using the given templates.

Just added a litte fix to ensure the line breaks are rendered correctly.