### PR TITLE
Added index to topics to speed up forum views

### DIFF
--- a/machina/apps/forum_conversation/abstract_models.py
+++ b/machina/apps/forum_conversation/abstract_models.py
@@ -93,6 +93,7 @@ class AbstractTopic(DatedModel):
         app_label = 'forum_conversation'
         ordering = ['-type', '-last_post_on', ]
         get_latest_by = 'last_post_on'
+        index_together = ['type', 'last_post_on']
         verbose_name = _('Topic')
         verbose_name_plural = _('Topics')
 

--- a/machina/apps/forum_permission/handler.py
+++ b/machina/apps/forum_permission/handler.py
@@ -71,7 +71,8 @@ class PermissionHandler(object):
         if not user.is_superuser:
             forums = self.get_readable_forums(forums, user)
 
-        return Post.approved_objects.filter(topic__forum__in=forums).order_by('-created').first()
+        return Post.approved_objects.filter(topic__forum__in=forums).order_by('-created').first()\
+            .select_related('topic', 'poster')
 
     def get_readable_forums(self, qs, user):
         """ Returns a queryset of forums that can be read by the considered user. """

--- a/machina/apps/forum_tracking/handler.py
+++ b/machina/apps/forum_tracking/handler.py
@@ -11,6 +11,8 @@ from machina.core.loading import get_class
 Forum = get_model('forum', 'Forum')
 ForumReadTrack = get_model('forum_tracking', 'ForumReadTrack')
 TopicReadTrack = get_model('forum_tracking', 'TopicReadTrack')
+Topic = get_model('forum_conversation', 'Topic')
+Post = get_model('forum_conversation', 'Post')
 
 PermissionHandler = get_class('forum_permission.handler', 'PermissionHandler')
 
@@ -21,6 +23,7 @@ class TrackingHandler(object):
     in order to get only the forums which contain unread topics or the unread
     topics.
     """
+
     def __init__(self, request=None):
         self.request = request
         self.perm_handler = request.forum_permission_handler if request \
@@ -47,45 +50,57 @@ class TrackingHandler(object):
         Returns a list of unread topics for the given user from a given
         set of topics.
         """
-        unread_topics = []
-
-        # A user which is not authenticated will never see a topic as unread.
-        # If there are no topics to consider, we stop here.
-        if not user.is_authenticated() or topics is None or not len(topics):
-            return unread_topics
-
-        # A topic can be unread if a track for itself exists with a mark time that
-        # is less important than its update date.
         topic_ids = [topic.id for topic in topics]
-        topic_tracks = TopicReadTrack.objects.filter(topic__in=topic_ids, user=user)
-        tracked_topics = dict(topic_tracks.values_list('topic__pk', 'mark_time'))
 
-        if tracked_topics:
-            for topic in topics:
-                topic_last_modification_date = topic.last_post_on or topic.created
-                if topic.id in tracked_topics.keys() \
-                        and topic_last_modification_date > tracked_topics[topic.id]:
-                    unread_topics.append(topic)
+        # build query constraints
 
-        # A topic can be unread if a track for its associated forum exists with
-        # a mark time that is less important than its creation or update date.
-        forum_ids = [topic.forum_id for topic in topics]
-        forum_tracks = ForumReadTrack.objects.filter(forum_id__in=forum_ids, user=user)
-        tracked_forums = dict(forum_tracks.values_list('forum__pk', 'mark_time'))
+        in_topics = Q(id__in=topic_ids)
 
-        if tracked_forums:
-            for topic in topics:
-                topic_last_modification_date = topic.last_post_on or topic.created
-                if ((topic.forum_id in tracked_forums.keys() and topic.id not in tracked_topics) and
-                        topic_last_modification_date > tracked_forums[topic.forum_id]):
-                    unread_topics.append(topic)
+        updated_after_last_read_topic = (Q(tracks__user=user)
+                                         & (Q(tracks__mark_time__lt=F('last_post_on'))
+                                            | (Q(tracks__mark_time__lt=F('created')))))
 
-        # A topic can be unread if no tracks exists for it
-        for topic in topics:
-            if topic.forum_id not in tracked_forums and topic.id not in tracked_topics:
-                unread_topics.append(topic)
+        updated_after_last_read_forum = (Q(forum__tracks__user=user)
+                                         & (Q(forum__tracks__mark_time__lt=F('last_post_on'))
+                                            | (Q(forum__tracks__mark_time__lt=F('created')))))
 
-        return list(set(unread_topics))
+        updated_before_last_read_topic = (Q(tracks__user=user)
+                                          & (Q(tracks__mark_time__gte=F('last_post_on'))
+                                             | (Q(tracks__mark_time__gte=F('created')))))
+
+        untracked = (~Q(tracks__user=self.request.user) & ~Q(forum__tracks__user=user))
+
+        untracked_ids = Topic.approved_objects.filter(in_topics & untracked).values_list('id', flat=True)
+
+        not_tracked = Q(id__in=untracked_ids)
+
+        # run query
+        unread_topics = Topic.approved_objects.filter(in_topics & ((updated_after_last_read_topic
+                                                           | (updated_after_last_read_forum
+                                                              & ~updated_before_last_read_topic))
+                                                          | not_tracked))
+
+        return unread_topics
+
+    def get_oldest_unread_post(self, topic, user):
+
+        if not user.is_authenticated() or topic is None:
+            return None
+
+        read_posts = Post.approved_objects.filter(Q(topic=topic)
+                                                  & Q(topic__tracks__mark_time__gte=F('created'))
+                                                  ).values_list("id", flat=True)
+
+        unread_posts = Post.approved_objects.filter(Q(topic=topic)
+                                                    & (Q(topic__tracks__mark_time__lt=F('created'))
+                                                       | (Q(topic__forum__tracks__mark_time__lt=F('created'))
+                                                          & ~Q(id__in=read_posts)))
+                                                    ).order_by('created')[:1]
+
+        if unread_posts:
+            return unread_posts[0].pk
+        else:
+            return None
 
     def mark_forums_read(self, forums, user):
         """
@@ -119,7 +134,7 @@ class TrackingHandler(object):
             forum_track = None
 
         if forum_track is None \
-                or (topic.last_post_on and forum_track.mark_time < topic.last_post_on):
+            or (topic.last_post_on and forum_track.mark_time < topic.last_post_on):
             topic_track, created = TopicReadTrack.objects.get_or_create(topic=topic, user=user)
             if not created:
                 topic_track.save()  # mark_time filled
@@ -133,8 +148,8 @@ class TrackingHandler(object):
 
             forum_topic_tracks = TopicReadTrack.objects.filter(topic__forum=forum, user=user)
             if not unread_topics.exists() and (
-                    forum_track is not None or
-                    forum_topic_tracks.count() == forum.topics.filter(approved=True).count()):
+                        forum_track is not None or
+                        forum_topic_tracks.count() == forum.topics.filter(approved=True).count()):
                 # The topics that are marked as read inside the forum for the given user will be
                 # deleted while the forum track associated with the user must be created or updated.
                 # This is done only if there are as many topic tracks as approved topics in case

--- a/machina/apps/forum_tracking/handler.py
+++ b/machina/apps/forum_tracking/handler.py
@@ -50,6 +50,12 @@ class TrackingHandler(object):
         Returns a list of unread topics for the given user from a given
         set of topics.
         """
+
+        # A user which is not authenticated will never see a topic as unread.
+        # If there are no topics to consider, we stop here.
+        if not user.is_authenticated() or topics is None or not len(topics):
+            return []
+
         topic_ids = [topic.id for topic in topics]
 
         # build query constraints

--- a/machina/templates/machina/forum_conversation/topic_list.html
+++ b/machina/templates/machina/forum_conversation/topic_list.html
@@ -25,7 +25,8 @@
                 <i class="fa {% if topic.is_sticky %}fa-lightbulb-o{% elif topic.is_announce %}fa-info{% else %}fa-dot-circle-o{% endif %} fa-2x"></i>
               </td>
               <td class="topic-name">
-                <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}" class="topic-name-link">{{ topic.subject }}</a>{% if topic.is_locked %}&nbsp;<i class="fa fa-times-circle locked-indicator" title="{% trans 'This topic is locked' %}"></i>{% endif %}
+                {% if topic in unread_topics or force_all_unread %}{% get_oldest_unread_post topic request.user as oldest_unread_post %}{% endif %}
+                <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}{% if oldest_unread_post != None %}?post={{ oldest_unread_post }}#{{ oldest_unread_post }}{% endif %}" class="topic-name-link">{{ topic.subject }}</a>{% if topic.is_locked %}&nbsp;<i class="fa fa-times-circle locked-indicator" title="{% trans 'This topic is locked' %}"></i>{% endif %}
                 <div>
                   <div class="topic-created">
                   {% if topic.poster %}

--- a/machina/templatetags/forum_tracking_tags.py
+++ b/machina/templatetags/forum_tracking_tags.py
@@ -35,3 +35,16 @@ def get_unread_topics(context, topics, user):
     """
     request = context.get('request', None)
     return TrackingHandler(request=request).get_unread_topics(topics, user)
+
+
+@register.assignment_tag(takes_context=True)
+def get_oldest_unread_post(context, topic, user):
+    """
+    This will return the oldest unread post for the given user from a given topic.
+
+    Usage::
+
+        {% get_oldest_unread_post topic request.user as oldest_unread_post %}
+    """
+    request = context.get('request', None)
+    return TrackingHandler(request=request).get_oldest_unread_post(topic, user)


### PR DESCRIPTION
The code in `apps/forum/views.py` selects the latest topics ordered by type and last_post_on which is in forum_conversation_topic. Adding an index allows the database to use a btree index scan instead of heapsort. This yields a massive performance improvement in query time. Sample below in forum with 1.1m posts

```
Executed SQL
    SELECT ••• FROM "forum_conversation_topic" LEFT OUTER JOIN "accounts_user" ON ("forum_conversation_topic"."poster_id" = "accounts_user"."id") LEFT OUTER JOIN "forum_conversation_post" ON ("forum_conversation_topic"."last_post_id" = "forum_conversation_post"."id") LEFT OUTER JOIN "accounts_user" T5 ON ("forum_conversation_post"."poster_id" = T5."id") WHERE ("forum_conversation_topic"."forum_id" = 9 AND NOT ("forum_conversation_topic"."type" = 2) AND NOT ("forum_conversation_topic"."approved" = false)) ORDER BY "forum_conversation_topic"."type" DESC, "forum_conversation_topic"."last_post_on" DESC LIMIT 20
Time
    334.56873893737793 ms
Database
    default

```

Before indexing
```
QUERY PLAN
Limit  (cost=219444.88..219444.93 rows=20 width=1878) (actual time=369.051..369.065 rows=20 loops=1)
  ->  Sort  (cost=219444.88..219561.82 rows=46779 width=1878) (actual time=369.051..369.064 rows=20 loops=1)
        Sort Key: forum_conversation_topic.type DESC, forum_conversation_topic.last_post_on DESC
        Sort Method: top-N heapsort  Memory: 47kB
        ->  Hash Left Join  (cost=908.51..218200.11 rows=46779 width=1878) (actual time=6.636..329.387 rows=46749 loops=1)
              Hash Cond: (forum_conversation_post.poster_id = t5.id)
              ->  Nested Loop Left Join  (cost=454.47..217102.85 rows=46779 width=1779) (actual time=3.586..298.115 rows=46749 loops=1)
                    ->  Hash Left Join  (cost=454.04..5389.46 rows=46779 width=207) (actual time=3.571..63.752 rows=46749 loops=1)
                          Hash Cond: (forum_conversation_topic.poster_id = accounts_user.id)
                          ->  Seq Scan on forum_conversation_topic  (cost=0.00..4292.21 rows=46779 width=108) (actual time=0.010..33.853 rows=46749 loops=1)
                                Filter: (approved AND (type <> 2) AND (forum_id = 9))
                                Rows Removed by Filter: 82265
                          ->  Hash  (cost=311.24..311.24 rows=11424 width=99) (actual time=3.526..3.526 rows=11424 loops=1)
                                Buckets: 16384  Batches: 1  Memory Usage: 1649kB
                                ->  Seq Scan on accounts_user  (cost=0.00..311.24 rows=11424 width=99) (actual time=0.006..1.763 rows=11424 loops=1)
                    ->  Index Scan using forum_conversation_post_pkey on forum_conversation_post  (cost=0.43..4.52 rows=1 width=1572) (actual time=0.004..0.004 rows=1 loops=46749)
                          Index Cond: (forum_conversation_topic.last_post_id = id)
              ->  Hash  (cost=311.24..311.24 rows=11424 width=99) (actual time=3.006..3.006 rows=11424 loops=1)
                    Buckets: 16384  Batches: 1  Memory Usage: 1649kB
                    ->  Seq Scan on accounts_user t5  (cost=0.00..311.24 rows=11424 width=99) (actual time=0.004..1.190 rows=11424 loops=1)
Planning time: 1.192 ms
Execution time: 369.159 ms
```

After indexing

```
QUERY PLAN
Limit  (cost=1.42..109.13 rows=20 width=1878) (actual time=0.018..0.334 rows=20 loops=1)
  ->  Nested Loop Left Join  (cost=1.42..251930.88 rows=46779 width=1878) (actual time=0.018..0.332 rows=20 loops=1)
        ->  Nested Loop Left Join  (cost=1.13..237294.42 rows=46779 width=1779) (actual time=0.016..0.283 rows=20 loops=1)
              ->  Nested Loop Left Join  (cost=0.70..25581.03 rows=46779 width=207) (actual time=0.013..0.190 rows=20 loops=1)
                    ->  Index Scan Backward using forum_conversation_topic_type_last_post_on_idx on forum_conversation_topic  (cost=0.42..10034.59 rows=46779 width=108) (actual time=0.009..0.138 rows=20 loops=1)
                          Filter: (approved AND (type <> 2) AND (forum_id = 9))
                          Rows Removed by Filter: 37
                    ->  Index Scan using accounts_user_pkey on accounts_user  (cost=0.29..0.32 rows=1 width=99) (actual time=0.002..0.002 rows=1 loops=20)
                          Index Cond: (forum_conversation_topic.poster_id = id)
              ->  Index Scan using forum_conversation_post_pkey on forum_conversation_post  (cost=0.43..4.52 rows=1 width=1572) (actual time=0.004..0.004 rows=1 loops=20)
                    Index Cond: (forum_conversation_topic.last_post_id = id)
        ->  Index Scan using accounts_user_pkey on accounts_user t5  (cost=0.29..0.30 rows=1 width=99) (actual time=0.002..0.002 rows=1 loops=20)
              Index Cond: (forum_conversation_post.poster_id = id)
Planning time: 1.025 ms
Execution time: 0.403 ms
```
