### PR TITLE
Resolve login url to avoid DisallowedRedirect

### DIFF
--- a/machina/apps/forum_permission/viewmixins.py
+++ b/machina/apps/forum_permission/viewmixins.py
@@ -9,6 +9,7 @@ from django.contrib.auth.decorators import REDIRECT_FIELD_NAME
 from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
+from django.shortcuts import resolve_url
 from django.utils.http import urlquote
 from django.utils.six import string_types
 
@@ -90,7 +91,7 @@ class PermissionRequiredMixin(object):
 
         if not has_permissions and not user.is_authenticated():
             return HttpResponseRedirect('{}?{}={}'.format(
-                self.login_url,
+                resolve_url(self.login_url),
                 self.redirect_field_name,
                 urlquote(request.get_full_path())
             ))


### PR DESCRIPTION
The value of `settings.LOGIN_URL` can be [a named url like 'authentication:login' in addition to being a plain url](https://docs.djangoproject.com/en/1.11/ref/settings/#login-url). 

But since the check_permissions()  in /machina/apps/forum_permission/viewmixins.py
just concatenates this setting with a querystring, the redirect url ends up as: `authentication:login?next=/forum/forum/some-forum-requiring-login/`, and you get a DisallowedRedirect: 
"Unsafe redirect to URL with protocol 'authentication'" when accessing the forum url without being logged in.

This PR fixes this by resolving the url before concatenating using the resolve_url shortcut method.

(The fix is based off of the 0.5.4 tag so that i could test how the fix works directly compared to the release version, but it should be simple to merge into master as the modified file is identical in both branches)
