### PR TITLE
Return None, instead of raising AttributeError on MarkupTextDescripto…

### DIFF
--- a/machina/models/fields.py
+++ b/machina/models/fields.py
@@ -109,7 +109,7 @@ class MarkupTextDescriptor(object):
 
     def __get__(self, instance, owner):
         if instance is None:
-            raise AttributeError(_('Can only be accessed via an instance.'))
+            return None
         raw = instance.__dict__[self.field.name]
         if raw is None:
             return None

--- a/tests/unit/forum/test_models.py
+++ b/tests/unit/forum/test_models.py
@@ -112,3 +112,9 @@ class TestForum(object):
             self.top_level_forum.parent = self.top_level_cat
             self.top_level_forum.save()
             assert receiver.call_count == 1
+
+    def test_get_or_create(self):
+        forum, created = Forum.objects.get_or_create(name="Test Forum", type=0)
+        assert created is True
+        assert isinstance(forum, Forum)
+        assert forum.name == "Test Forum"


### PR DESCRIPTION
Django 1.11.2 get_or_create object is passing in None instance, resulting in the AttributeError exception being raised.

Seeing that a None is returned if field name not in the instance, I thought returning None for no instance would be ok. Tests pass and functionality does not appear to be impacted, so hopefully that is ok.

Tests don't pass for Django 1.11.2, but went ahead and created an explicit test for get_or_create_object.

Thank you for contributing to django-machina! A list of simple rules is available on the online
documentation to help you contribute to this project: https://django-machina.readthedocs.org/en/stable/contributing.html.
Please review these guidelines before submitting your pull request!
