### PR TITLE
Removed superfluous open braces

### DIFF
--- a/machina/templates/machina/forum_conversation/post_delete.html
+++ b/machina/templates/machina/forum_conversation/post_delete.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Delete post" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Delete post" %}{% endblock sub_title %}
 
 {% block content %}
 	<div class="row">

--- a/machina/templates/machina/forum_member/topic_subscribe.html
+++ b/machina/templates/machina/forum_member/topic_subscribe.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Subscribe to topic" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Subscribe to topic" %}{% endblock sub_title %}
 
 {% block content %}
   <div class="row">

--- a/machina/templates/machina/forum_member/topic_unsubscribe.html
+++ b/machina/templates/machina/forum_member/topic_unsubscribe.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Unsubscribe from topic" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Unsubscribe from topic" %}{% endblock sub_title %}
 
 {% block content %}
   <div class="row">

--- a/machina/templates/machina/forum_moderation/moderation_queue/post_approve.html
+++ b/machina/templates/machina/forum_moderation/moderation_queue/post_approve.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Approve post" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Approve post" %}{% endblock sub_title %}
 
 {% block content %}
 	<div class="row">

--- a/machina/templates/machina/forum_moderation/moderation_queue/post_disapprove.html
+++ b/machina/templates/machina/forum_moderation/moderation_queue/post_disapprove.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Disapprove post" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Disapprove post" %}{% endblock sub_title %}
 
 {% block content %}
 	<div class="row">

--- a/machina/templates/machina/forum_moderation/topic_lock.html
+++ b/machina/templates/machina/forum_moderation/topic_lock.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Lock topic" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Lock topic" %}{% endblock sub_title %}
 
 {% block content %}
 	<div class="row">

--- a/machina/templates/machina/forum_moderation/topic_move.html
+++ b/machina/templates/machina/forum_moderation/topic_move.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Move topic" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Move topic" %}{% endblock sub_title %}
 
 {% block content %}
 	<div class="row">

--- a/machina/templates/machina/forum_moderation/topic_unlock.html
+++ b/machina/templates/machina/forum_moderation/topic_unlock.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Unlock topic" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Unlock topic" %}{% endblock sub_title %}
 
 {% block content %}
 	<div class="row">

--- a/machina/templates/machina/forum_moderation/topic_update_type.html
+++ b/machina/templates/machina/forum_moderation/topic_update_type.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Change topic type" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Change topic type" %}{% endblock sub_title %}
 
 {% block content %}
 	<div class="row">

--- a/machina/templates/machina/forum_tracking/mark_forums_read.html
+++ b/machina/templates/machina/forum_tracking/mark_forums_read.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Mark forums read" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Mark forums read" %}{% endblock sub_title %}
 
 {% block content %}
 <div class="row">

--- a/machina/templates/machina/forum_tracking/mark_topics_read.html
+++ b/machina/templates/machina/forum_tracking/mark_topics_read.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load forum_conversation_tags %}
 
-{{% block sub_title %}{% trans "Mark topics read" %}{% endblock sub_title %}
+{% block sub_title %}{% trans "Mark topics read" %}{% endblock sub_title %}
 
 {% block content %}
 <div class="row">


### PR DESCRIPTION
I found these while working on another PR, but I felt it would make more sense to send this separately.

Although Django ignores them, these extra open braces made my syntax highlighter go crazy.