### PR TITLE
Three minor admin fixes

### DIFF
--- a/machina/apps/forum_permission/admin.py
+++ b/machina/apps/forum_permission/admin.py
@@ -20,14 +20,14 @@ class ForumPermissionAdmin(admin.ModelAdmin):
 
 class GroupForumPermissionAdmin(admin.ModelAdmin):
     search_fields = ('permission__codename', 'group__name', )
-    list_display = ('group', 'permission', 'has_perm', )
+    list_display = ('group', 'forum', 'permission', 'has_perm', )
     list_editables = ('has_perm', )
     raw_id_fields = ('group', )
 
 
 class UserForumPermissionAdmin(admin.ModelAdmin):
     search_fields = ('permission__codename', 'user__username', )
-    list_display = ('user', 'anonymous_user', 'permission', 'has_perm', )
+    list_display = ('user', 'anonymous_user', 'forum', 'permission', 'has_perm', )
     list_editables = ('has_perm', )
     raw_id_fields = ('user', )
 

--- a/machina/templates/admin/forum/forum/change_list_table.html
+++ b/machina/templates/admin/forum/forum/change_list_table.html
@@ -34,7 +34,11 @@
                     {% else %}
                         <i class="fa fa-arrow-circle-o-down fa-lg disabled"></i>
                     {% endif %}
-                    <a href="{% url 'admin:forum_forum_add' %}?parent={{ forum.id }}" class="success" title="{% trans "Add a sub-forum" %}"><i class="fa fa-plus-circle fa-lg"></i></a>
+                    {% if not forum.is_link %}
+                        <a href="{% url 'admin:forum_forum_add' %}?parent={{ forum.id }}" class="success" title="{% trans "Add a sub-forum" %}"><i class="fa fa-plus-circle fa-lg"></i></a>
+                    {% else %}
+                        <i class="fa fa-times-circle fa-lg disabled"></i>
+                    {% endif %}
                     <a href="{% url 'admin:forum_forum_delete' forum.id %}" class="danger" title="{% trans "Delete" %}"><i class="fa fa-times-circle fa-lg"></i></a>
                 </td>
                 <td class="type-cell">


### PR DESCRIPTION
The following fixes/enhancements have been made:

1 ) Show column with forum in the admin on the change list of user permissions and group permissions.
2 ) Do not allow creating of subforum below a link forum (disable button)  (So this now matches the warning you get on trying to save such a thing) See issue #120
3 ) Do not allow choosing 'category forum' as type when adding/editing a forum below another category forum. (So this now matches the warning you get on trying to save such a thing) See issue #120