### PR TITLE
Change text 'View my messages' to 'View my posts'

### DIFF
--- a/machina/templates/machina/board_base.html
+++ b/machina/templates/machina/board_base.html
@@ -54,7 +54,7 @@
       <div class="pull-right controls-link-wrapper">
       {% if not request.user.is_anonymous %}
         <a href="{% url 'forum_member:user_subscriptions' %}" class="btn btn-link"><i class="fa fa-bookmark-o ">&nbsp;</i>{% trans "Subscriptions" %}</a>
-        <a href="{% url 'forum_member:user_posts' request.user.id %}" class="btn btn-link"><i class="fa fa-comments-o ">&nbsp;</i>{% trans "View my messages" %}</a>
+        <a href="{% url 'forum_member:user_posts' request.user.id %}" class="btn btn-link"><i class="fa fa-comments-o ">&nbsp;</i>{% trans "View my posts" %}</a>
       {% endif %}
       {% get_permission 'can_access_moderation_queue' request.user as can_access_moderation_queue %}
       {% if can_access_moderation_queue %}


### PR DESCRIPTION
Fixes #127.
To prevent confusion: messages may be interpreted as personal/direct messages
instead of the replies/posts that are meant.
