### PR TITLE
Fix typo in view class name

### DIFF
--- a/machina/apps/forum_member/app.py
+++ b/machina/apps/forum_member/app.py
@@ -17,7 +17,7 @@ class MemberApp(Application):
     forum_profile_update_view = get_class('forum_member.views', 'ForumProfileUpdateView')
     topic_subscribe_view = get_class('forum_member.views', 'TopicSubscribeView')
     topic_unsubscribe_view = get_class('forum_member.views', 'TopicUnsubscribeView')
-    topic_subscription_list_view = get_class('forum_member.views', 'TopicSubscribtionListView')
+    topic_subscription_list_view = get_class('forum_member.views', 'TopicSubscriptionListView')
 
     def get_urls(self):
         return [

--- a/machina/apps/forum_member/views.py
+++ b/machina/apps/forum_member/views.py
@@ -200,7 +200,7 @@ class TopicUnsubscribeView(
         return self.request.forum_permission_handler.can_unsubscribe_from_topic(obj, user)
 
 
-class TopicSubscribtionListView(ListView):
+class TopicSubscriptionListView(ListView):
     """
     Provides a list of all topics to which the current user has subscribed.
     """
@@ -213,4 +213,4 @@ class TopicSubscribtionListView(ListView):
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
-        return super(TopicSubscribtionListView, self).dispatch(request, *args, **kwargs)
+        return super(TopicSubscriptionListView, self).dispatch(request, *args, **kwargs)

--- a/tests/functional/member/test_views.py
+++ b/tests/functional/member/test_views.py
@@ -336,7 +336,7 @@ class TestTopicUnsubscribeView(BaseClientTestCase):
         assert response.status_code == 403
 
 
-class TestTopicSubscribtionListView(BaseClientTestCase):
+class TestTopicSubscriptionListView(BaseClientTestCase):
     @pytest.fixture(autouse=True)
     def setup(self):
         # Add some users


### PR DESCRIPTION
I fixed a typo in the view class 'TopicSubscribtionListView' and its corresponding test class. Is this likely to cause any compatibility problems?
