### PR TITLE
Update urls to paths

### DIFF
--- a/example_project/example/apps/auth/urls.py
+++ b/example_project/example/apps/auth/urls.py
@@ -2,13 +2,13 @@ from django.urls import include, path
 
 from . import views
 
-
 urlpatterns = [
     path('account/', include('django.contrib.auth.urls')),
     path('account/parameters/edit/',
-        views.UserAccountParametersUpdateView.as_view(), name='account-parameters'),
+         views.UserAccountParametersUpdateView.as_view(),
+         name='account-parameters'),
     path('account/password/edit/',
-        views.UserPasswordUpdateView.as_view(), name='account-password'),
+         views.UserPasswordUpdateView.as_view(), name='account-password'),
     path('register/', views.UserCreateView.as_view(), name='register'),
     path('unregister/', views.UserDeleteView.as_view(), name='unregister'),
 ]

--- a/example_project/example/apps/auth/urls.py
+++ b/example_project/example/apps/auth/urls.py
@@ -1,15 +1,14 @@
-from django.conf.urls import include
-from django.conf.urls import url
+from django.urls import include, path
 
 from . import views
 
 
 urlpatterns = [
-    url(r'^account/', include('django.contrib.auth.urls')),
-    url(r'^account/parameters/edit/',
+    path('account/', include('django.contrib.auth.urls')),
+    path('account/parameters/edit/',
         views.UserAccountParametersUpdateView.as_view(), name='account-parameters'),
-    url(r'^account/password/edit/',
+    path('account/password/edit/',
         views.UserPasswordUpdateView.as_view(), name='account-password'),
-    url(r'^register/', views.UserCreateView.as_view(), name='register'),
-    url(r'^unregister/', views.UserDeleteView.as_view(), name='unregister'),
+    path('register/', views.UserCreateView.as_view(), name='register'),
+    path('unregister/', views.UserDeleteView.as_view(), name='unregister'),
 ]

--- a/example_project/example_project/urls.py
+++ b/example_project/example_project/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include
-from django.conf.urls import url
+from django.urls import path, include
 from django.contrib import admin
 from django.views.i18n import JavaScriptCatalog
 from machina import urls as machina_urls
@@ -11,20 +10,20 @@ js_info_dict = {
 }
 
 urlpatterns = [
-    url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript_catalog'),
+    path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript_catalog'),
 
     # Admin
-    url(r'^' + settings.ADMIN_URL, admin.site.urls),
+    path('' + settings.ADMIN_URL, admin.site.urls),
 
     # Apps
-    url(r'', include('example.apps.auth.urls')),
-    url(r'', include(machina_urls)),
+    path('', include('example.apps.auth.urls')),
+    path('', include(machina_urls)),
 ]
 
 if settings.DEBUG:
     # Add the Debug Toolbar’s URLs to the project’s URLconf
     import debug_toolbar
-    urlpatterns += [url(r'^__debug__/', include(debug_toolbar.urls)), ]
+    urlpatterns += [path('^__debug__/', include(debug_toolbar.urls)), ]
 
     # In DEBUG mode, serve media files through Django.
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -33,6 +32,6 @@ if settings.DEBUG:
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
     urlpatterns += [
-        url(r'^%s/(?P<path>.*)$' % media_url, static.serve,
+        path('^%s/<path>' % media_url, static.serve,
             {'document_root': settings.MEDIA_ROOT}),
     ]

--- a/example_project/example_project/urls.py
+++ b/example_project/example_project/urls.py
@@ -23,7 +23,7 @@ if settings.DEBUG:
     # Add the Debug Toolbar’s URLs to the project’s URLconf
     import debug_toolbar
 
-    urlpatterns += [path('^__debug__/', include(debug_toolbar.urls)), ]
+    urlpatterns += [path('__debug__/', include(debug_toolbar.urls)), ]
 
     # In DEBUG mode, serve media files through Django.
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
@@ -33,6 +33,6 @@ if settings.DEBUG:
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
     urlpatterns += [
-        path('^%s/<path>' % media_url, static.serve,
+        path('%s/<path>' % media_url, static.serve,
              {'document_root': settings.MEDIA_ROOT}),
     ]

--- a/example_project/example_project/urls.py
+++ b/example_project/example_project/urls.py
@@ -1,12 +1,11 @@
 from django.conf import settings
-from django.urls import path, include
+from django.urls import include, path
 from django.contrib import admin
 from django.views.i18n import JavaScriptCatalog
 from machina import urls as machina_urls
 
-
 js_info_dict = {
-    'packages': ('base', ),
+    'packages': ('base',),
 }
 
 urlpatterns = [
@@ -23,15 +22,17 @@ urlpatterns = [
 if settings.DEBUG:
     # Add the Debug Toolbar’s URLs to the project’s URLconf
     import debug_toolbar
+
     urlpatterns += [path('^__debug__/', include(debug_toolbar.urls)), ]
 
     # In DEBUG mode, serve media files through Django.
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
     from django.views import static
+
     urlpatterns += staticfiles_urlpatterns()
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
     urlpatterns += [
         path('^%s/<path>' % media_url, static.serve,
-            {'document_root': settings.MEDIA_ROOT}),
+             {'document_root': settings.MEDIA_ROOT}),
     ]

--- a/machina/apps/forum/urls.py
+++ b/machina/apps/forum/urls.py
@@ -6,7 +6,7 @@
 
 """
 
-from django.conf.urls import url
+from django.urls import path
 from django.utils.translation import ugettext_lazy as _
 
 from machina.core.loading import get_class
@@ -24,9 +24,9 @@ class ForumURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(r'^$', self.index_view.as_view(), name='index'),
-            url(
-                _(r'^forum/(?P<slug>[\w-]+)-(?P<pk>\d+)/$'),
+            path('', self.index_view.as_view(), name='index'),
+            path(
+                _('forum/<slug>-<pk>/'),
                 self.forum_view.as_view(),
                 name='forum',
             ),

--- a/machina/apps/forum_conversation/forum_attachments/urls.py
+++ b/machina/apps/forum_conversation/forum_attachments/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.conf.urls import url
+from django.urls import path
 
 from machina.core.loading import get_class
 from machina.core.urls import URLPatternsFactory
@@ -16,12 +16,16 @@ from machina.core.urls import URLPatternsFactory
 class ForumAttachmentsURLPatternsFactory(URLPatternsFactory):
     """ Allows to generate the URL patterns of the ``forum_attachments`` application. """
 
-    attachment_view = get_class('forum_conversation.forum_attachments.views', 'AttachmentView')
+    attachment_view = get_class(
+        'forum_conversation.forum_attachments.views', 'AttachmentView')
 
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(r'^attachment/(?P<pk>\d+)/$', self.attachment_view.as_view(), name='attachment'),
+            path('attachment/<pk>/',
+                 self.attachment_view.as_view(),
+                 name='attachment'
+                 ),
         ]
 
 

--- a/machina/apps/forum_conversation/forum_polls/urls.py
+++ b/machina/apps/forum_conversation/forum_polls/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.conf.urls import url
+from django.urls import path
 
 from machina.core.loading import get_class
 from machina.core.urls import URLPatternsFactory
@@ -16,12 +16,16 @@ from machina.core.urls import URLPatternsFactory
 class ForumPollsURLPatternsFactory(URLPatternsFactory):
     """ Allows to generate the URL patterns of the ``forum_polls`` application. """
 
-    poll_vote_view = get_class('forum_conversation.forum_polls.views', 'TopicPollVoteView')
+    poll_vote_view = get_class(
+        'forum_conversation.forum_polls.views', 'TopicPollVoteView')
 
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(r'^poll/(?P<pk>\d+)/vote/$', self.poll_vote_view.as_view(), name='topic_poll_vote'),
+            path('poll/<pk>/vote/',
+                 self.poll_vote_view.as_view(),
+                 name='topic_poll_vote'
+                 ),
         ]
 
 

--- a/machina/apps/forum_conversation/urls.py
+++ b/machina/apps/forum_conversation/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.urls import path, include
+from django.urls import include, path
 from django.utils.translation import ugettext_lazy as _
 
 from machina.apps.forum_conversation.forum_attachments.urls import \

--- a/machina/apps/forum_conversation/urls.py
+++ b/machina/apps/forum_conversation/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.conf.urls import include, url
+from django.urls import path, include
 from django.utils.translation import ugettext_lazy as _
 
 from machina.apps.forum_conversation.forum_attachments.urls import \
@@ -35,36 +35,42 @@ class BaseForumConversationURLPatternsFactory(URLPatternsFactory):
         urlpatterns = super().get_urlpatterns()
 
         conversation_urlpatterns = [
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/$'),
+            path(
+                _('topic/<slug>-<pk>/'),
                 self.topic_view.as_view(),
                 name='topic',
             ),
-
-            url(_(r'^topic/create/$'), self.topic_create_view.as_view(), name='topic_create'),
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/update/$'),
+            path(_(
+                'topic/create/'),
+                self.topic_create_view.as_view(),
+                name='topic_create'
+            ),
+            path(
+                _('topic/<slug>-<pk>/update/'),
                 self.topic_update_view.as_view(),
                 name='topic_update',
             ),
 
-            url(
-                _(r'^topic/(?P<topic_slug>[\w-]+)-(?P<topic_pk>\d+)/post/create/$'),
+            path(
+                _('topic/<topic_slug>-<topic_pk>/post/create/'),
                 self.post_create_view.as_view(),
                 name='post_create',
             ),
-            url(
-                _(r'^topic/(?P<topic_slug>[\w-]+)-(?P<topic_pk>\d+)/(?P<pk>\d+)/post/update/$'),
+            path(
+                _('topic/<topic_slug>-<topic_pk>/<pk>/post/update/'),
                 self.post_update_view.as_view(),
                 name='post_update',
             ),
-            url(_(r'^topic/(?P<topic_slug>[\w-]+)-(?P<topic_pk>\d+)/(?P<pk>\d+)/post/delete/$'),
-                self.post_delete_view.as_view(), name='post_delete'),
+            path(
+                _('topic/<topic_slug>-<topic_pk>/<pk>/post/delete/'),
+                self.post_delete_view.as_view(),
+                name='post_delete'
+            ),
         ]
 
         urlpatterns += [
-            url(
-                _(r'forum/(?P<forum_slug>[\w-]+)-(?P<forum_pk>\d+)/'),
+            path(
+                _('forum/<forum_slug>-<forum_pk>/'),
                 include(conversation_urlpatterns),
             ),
         ]
@@ -80,7 +86,7 @@ class ForumAttachmentsURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return super().get_urlpatterns() + [
-            url(r'^', include(self.attachments_urlpatterns_factory.urlpatterns)),
+            path('', include(self.attachments_urlpatterns_factory.urlpatterns)),
         ]
 
 
@@ -92,7 +98,7 @@ class ForumPollsURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return super().get_urlpatterns() + [
-            url(r'^', include(self.polls_urlpatterns_factory.urlpatterns)),
+            path('', include(self.polls_urlpatterns_factory.urlpatterns)),
         ]
 
 

--- a/machina/apps/forum_feeds/urls.py
+++ b/machina/apps/forum_feeds/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.conf.urls import url
+from django.urls import path
 from django.utils.translation import ugettext_lazy as _
 
 from machina.core.loading import get_class
@@ -24,14 +24,17 @@ class ForumFeedsURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(_(r'^topics/$'), self.latest_topics_feed(), name='latest_topics'),
-            url(
-                _(r'^forum/(?P<forum_slug>[\w-]+)-(?P<forum_pk>\d+)/topics/$'),
+            path(_('topics/'),
+                 self.latest_topics_feed(),
+                 name='latest_topics'
+                 ),
+            path(
+                _('forum/<forum_slug>-<forum_pk>/topics/'),
                 self.latest_topics_feed(),
                 name='forum_latest_topics',
             ),
-            url(
-                _(r'^forum/(?P<forum_slug>[\w-]+)-(?P<forum_pk>\d+)/topics/all/$'),
+            path(
+                _('forum/<forum_slug>-<forum_pk>/topics/all/'),
                 self.latest_topics_feed(),
                 {'descendants': True},
                 name='forum_latest_topics_with_descendants',

--- a/machina/apps/forum_member/urls.py
+++ b/machina/apps/forum_member/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.conf.urls import url
+from django.urls import path
 from django.utils.translation import ugettext_lazy as _
 
 from machina.core.loading import get_class
@@ -29,33 +29,33 @@ class ForumMemberURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(
-                _(r'^profile/(?P<pk>\d+)/$'),
+            path(
+                _('profile/<pk>/'),
                 self.forum_profile_detail_view.as_view(),
                 name='profile',
             ),
-            url(
-                _(r'^profile/(?P<pk>\d+)/posts/$'),
+            path(
+                _('profile/<pk>/posts/'),
                 self.user_posts_list.as_view(),
                 name='user_posts',
             ),
-            url(
-                _(r'^profile/edit/$'),
+            path(
+                _('profile/edit/'),
                 self.forum_profile_update_view.as_view(),
                 name='profile_update',
             ),
-            url(
-                _(r'^subscriptions/$'),
+            path(
+                _('subscriptions/'),
                 self.topic_subscription_list_view.as_view(),
                 name='user_subscriptions',
             ),
-            url(
-                _(r'^topic/(?P<pk>\d+)/subscribe/$'),
+            path(
+                _('topic/<pk>/subscribe/'),
                 self.topic_subscribe_view.as_view(),
                 name='topic_subscribe',
             ),
-            url(
-                _(r'^topic/(?P<pk>\d+)/unsubscribe/$'),
+            path(
+                _('topic/<pk>/unsubscribe/'),
                 self.topic_unsubscribe_view.as_view(),
                 name='topic_unsubscribe',
             ),

--- a/machina/apps/forum_moderation/urls.py
+++ b/machina/apps/forum_moderation/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.conf.urls import url
+from django.urls import path
 from django.utils.translation import ugettext_lazy as _
 
 from machina.core.loading import get_class
@@ -38,54 +38,54 @@ class ForumModerationURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/lock/$'),
+            path(
+                _('topic/<slug>-<pk>/lock/'),
                 self.topic_lock_view.as_view(),
                 name='topic_lock',
             ),
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/unlock/$'),
+            path(
+                _('topic/<slug>-<pk>/unlock/'),
                 self.topic_unlock_view.as_view(),
                 name='topic_unlock',
             ),
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/delete/$'),
+            path(
+                _('topic/<slug>-<pk>/delete/'),
                 self.topic_delete_view.as_view(),
                 name='topic_delete',
             ),
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/move/$'),
+            path(
+                _('topic/<slug>-<pk>/move/'),
                 self.topic_move_view.as_view(),
                 name='topic_move',
             ),
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/change/topic/$'),
+            path(
+                _('topic/<slug>-<pk>/change/topic/'),
                 self.topic_update_to_normal_topic_view.as_view(),
                 name='topic_update_to_post',
             ),
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/change/sticky/$'),
+            path(
+                _('topic/<slug>-<pk>/change/sticky/'),
                 self.topic_update_to_sticky_topic_view.as_view(),
                 name='topic_update_to_sticky',
             ),
-            url(
-                _(r'^topic/(?P<slug>[\w-]+)-(?P<pk>\d+)/change/announce/$'),
+            path(
+                _('topic/<slug>-<pk>/change/announce/'),
                 self.topic_update_to_announce_view.as_view(),
                 name='topic_update_to_announce',
             ),
-            url(_(r'^queue/$'), self.moderation_queue_list_view.as_view(), name='queue'),
-            url(
-                _(r'^queue/(?P<pk>\d+)/$'),
+            path(_('queue/'), self.moderation_queue_list_view.as_view(), name='queue'),
+            path(
+                _('queue/<pk>/'),
                 self.moderation_queue_detail_view.as_view(),
                 name='queued_post',
             ),
-            url(
-                _(r'^queue/(?P<pk>\d+)/approve/$'),
+            path(
+                _('queue/<pk>/approve/'),
                 self.post_approve_view.as_view(),
                 name='approve_queued_post',
             ),
-            url(
-                _(r'^queue/(?P<pk>\d+)/disapprove/$'),
+            path(
+                _('queue/<pk>/disapprove/'),
                 self.post_disapprove_view.as_view(),
                 name='disapprove_queued_post',
             ),

--- a/machina/apps/forum_search/urls.py
+++ b/machina/apps/forum_search/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.conf.urls import url
+from django.urls import path
 from haystack.views import search_view_factory
 
 from machina.core.loading import get_class
@@ -25,9 +25,10 @@ class ForumSearchURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(
-                r'^$',
-                search_view_factory(view_class=self.search_view, form_class=self.search_form),
+            path(
+                '',
+                search_view_factory(
+                    view_class=self.search_view, form_class=self.search_form),
                 name='search',
             ),
         ]

--- a/machina/apps/forum_tracking/urls.py
+++ b/machina/apps/forum_tracking/urls.py
@@ -7,7 +7,7 @@
 
 """
 
-from django.conf.urls import url
+from django.urls import path
 from django.utils.translation import ugettext_lazy as _
 
 from machina.core.loading import get_class
@@ -26,23 +26,23 @@ class ForumTrackingURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(
-                _(r'^mark/forums/$'),
+            path(
+                _('mark/forums/'),
                 self.mark_forums_read_view.as_view(),
                 name='mark_all_forums_read',
             ),
-            url(
-                _(r'^mark/forums/(?P<pk>\d+)/$'),
+            path(
+                _('mark/forums/<pk>/'),
                 self.mark_forums_read_view.as_view(),
                 name='mark_subforums_read',
             ),
-            url(
-                _(r'^mark/forum/(?P<pk>\d+)/topics/$'),
+            path(
+                _('mark/forum/<pk>/topics/'),
                 self.mark_topics_read_view.as_view(),
                 name='mark_topics_read',
             ),
-            url(
-                _(r'^unread-topics/$'),
+            path(
+                _('unread-topics/'),
                 self.unread_topics_view.as_view(),
                 name='unread_topics',
             ),

--- a/machina/urls.py
+++ b/machina/urls.py
@@ -6,7 +6,7 @@
 
 """
 
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.utils.translation import ugettext_lazy as _
 
 from machina.core.loading import get_class
@@ -27,13 +27,13 @@ class BoardURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(r'', include(self.forum_urlpatterns_factory.urlpatterns)),
-            url(r'', include(self.conversation_urlpatterns_factory.urlpatterns)),
-            url(_(r'^feeds/'), include(self.feeds_urlpatterns_factory.urlpatterns)),
-            url(_(r'^member/'), include(self.member_urlpatterns_factory.urlpatterns)),
-            url(_(r'^moderation/'), include(self.moderation_urlpatterns_factory.urlpatterns)),
-            url(_(r'^search/'), include(self.search_urlpatterns_factory.urlpatterns)),
-            url(_(r'^tracking/'), include(self.tracking_urlpatterns_factory.urlpatterns)),
+            path('', include(self.forum_urlpatterns_factory.urlpatterns)),
+            path('', include(self.conversation_urlpatterns_factory.urlpatterns)),
+            path(_('feeds/'), include(self.feeds_urlpatterns_factory.urlpatterns)),
+            path(_('member/'), include(self.member_urlpatterns_factory.urlpatterns)),
+            path(_('moderation/'), include(self.moderation_urlpatterns_factory.urlpatterns)),
+            path(_('search/'), include(self.search_urlpatterns_factory.urlpatterns)),
+            path(_('tracking/'), include(self.tracking_urlpatterns_factory.urlpatterns)),
         ]
 
 

--- a/tests/_testsite/urls.py
+++ b/tests/_testsite/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.conf.urls import url
+from django.urls import include, path
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
@@ -9,7 +8,7 @@ from machina import urls as machina_urls
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'', include(machina_urls)),
+    path('admin/', admin.site.urls),
+    path('', include(machina_urls)),
 ]
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
So a problem I faced earlier:

I switched my User model to use UUID for User IDs which broke my forum.  This is due to the original URL regex specifying digits only.  To remedy it, and upgrade it, I converted all URLs to paths.  I have also verified that this works without a problem through my site.

Let me know if there is anything I missed or needs to be changed!

