### PR TITLE
Permission precedence fix

### DIFF
--- a/machina/apps/forum_permission/checker.py
+++ b/machina/apps/forum_permission/checker.py
@@ -48,7 +48,7 @@ class ForumPermissionChecker:
         if forum.id not in self._forum_perms_cache:
             if self.user and self.user.is_superuser:
                 # The superuser has all the permissions.
-                perms = list(ForumPermission.objects.values_list('codename', flat=True))
+                permcodes = list(ForumPermission.objects.values_list('codename', flat=True))
             elif self.user:
                 default_auth_forum_perms = (
                     machina_settings.DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS
@@ -70,15 +70,22 @@ class ForumPermissionChecker:
                 globally_granted_user_perms = list(
                     filter(lambda p: p.has_perm and p.forum_id is None, user_perms)
                 )
-                globally_granted_user_perms = [
+                globally_granted_user_permcodes = [
                     p.permission.codename for p in globally_granted_user_perms
                 ]
+                globally_nongranted_user_perms = list(
+                    filter(lambda p: not p.has_perm and p.forum_id is None, user_perms)
+                )
+                # If the considered user have no global permissions, the permissions defined by the
+                # DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS settings are used instead.
+                if self.user.is_authenticated and not globally_granted_user_perms:
+                    globally_granted_user_permcodes = default_auth_forum_perms
 
                 # Computes the list of permissions that are granted on a per-forum basis.
                 per_forum_granted_user_perms = list(
                     filter(lambda p: p.has_perm and p.forum_id is not None, user_perms)
                 )
-                per_forum_granted_user_perms = [
+                per_forum_granted_user_permcodes = [
                     p.permission.codename for p in per_forum_granted_user_perms
                 ]
 
@@ -86,25 +93,25 @@ class ForumPermissionChecker:
                 per_forum_nongranted_user_perms = list(
                     filter(lambda p: not p.has_perm and p.forum_id is not None, user_perms)
                 )
-                per_forum_nongranted_user_perms = [
+                per_forum_nongranted_user_permcodes = [
                     p.permission.codename for p in per_forum_nongranted_user_perms
                 ]
 
-                # If the considered user have no global permissions, the permissions defined by the
-                # DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS settings are used instead.
-                if self.user.is_authenticated and not globally_granted_user_perms:
-                    globally_granted_user_perms = default_auth_forum_perms
-
-                # Finally computes the list of permission codenames that are granted to the user for
-                # the considered forum.
-                granted_user_perms = [
-                    c for c in globally_granted_user_perms if
-                    c not in per_forum_nongranted_user_perms
+                # Finally computes the list of permission codenames that are
+                # granted to the user for the considered forum.
+                # We can not do this earlier because
+                # globally_granted_user_perms can be from the setting
+                # DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS in which case
+                # it only contains permission codes and not actual permission
+                # objects that we can loop over and check against.
+                granted_user_permcodes = [
+                    c for c in globally_granted_user_permcodes if
+                    c not in per_forum_nongranted_user_permcodes
                 ]
-                granted_user_perms += per_forum_granted_user_perms
-                granted_user_perms = set(granted_user_perms)
+                granted_user_permcodes = set(granted_user_permcodes +
+                                             per_forum_granted_user_permcodes)
 
-                perms = granted_user_perms
+                permcodes = granted_user_permcodes
 
                 # If the user is a registered user, we have to check the permissions of its groups
                 # in order to determine the additional permissions they could have.
@@ -115,41 +122,47 @@ class ForumPermissionChecker:
                         .filter(Q(forum__isnull=True) | Q(forum=forum))
                     )
 
-                    globally_granted_group_perms = list(
-                        filter(lambda p: p.has_perm and p.forum_id is None, group_perms)
+                    # A permission can be non-granted on user-forum level, and that takes
+                    # precedence over granted group permissions so we do not add those to the list.
+                    per_forum_granted_group_perms = list(
+                        filter(lambda p: p.has_perm and p.forum_id is not None and
+                               p.permission_id not in
+                               [q.permission_id for q in per_forum_nongranted_user_perms],
+                               group_perms)
                     )
-                    globally_granted_group_perms = [
+                    per_forum_granted_group_permcodes = [
+                        p.permission.codename for p in per_forum_granted_group_perms
+                    ]
+                    # A permission can be granted on user-forum level, and that takes precedence
+                    # over nongranted group permissions so we do not add those to the list.
+                    per_forum_nongranted_group_perms = list(
+                        filter(lambda p: not p.has_perm and p.forum_id is not None and
+                               p.permission_id not in
+                               [q.permission_id for q in per_forum_granted_user_perms],
+                               group_perms)
+                    )
+
+                    # Only get the globally granted group perms that were:
+                    # - not set to non-granted on global-user level
+                    # - and not set to non-granted on forum-group level
+                    globally_granted_group_perms = list(
+                        filter(lambda p: p.has_perm and p.forum_id is None and
+                               p.permission_id not in
+                               [q.permission_id for q in globally_nongranted_user_perms] and
+                               p.permission_id not in
+                               [y.permission_id for y in per_forum_nongranted_group_perms],
+                               group_perms)
+                    )
+                    globally_granted_group_permcodes = [
                         p.permission.codename for p in globally_granted_group_perms
                     ]
 
-                    per_forum_granted_group_perms = list(
-                        filter(lambda p: p.has_perm and p.forum_id is not None, group_perms)
-                    )
-                    per_forum_granted_group_perms = [
-                        p.permission.codename for p in per_forum_granted_group_perms
-                    ]
-
-                    per_forum_nongranted_group_perms = list(
-                        filter(lambda p: not p.has_perm and p.forum_id is not None, group_perms)
-                    )
-                    per_forum_nongranted_group_perms = [
-                        p.permission.codename for p in per_forum_nongranted_group_perms
-                    ]
-
-                    granted_group_perms = [
-                        c for c in globally_granted_group_perms if
-                        c not in per_forum_nongranted_group_perms
-                    ]
-                    granted_group_perms += per_forum_granted_group_perms
-                    granted_group_perms = filter(
-                        lambda x: x not in per_forum_nongranted_user_perms, granted_group_perms
-                    )
-                    granted_group_perms = set(granted_group_perms)
+                    granted_group_permcodes = set(globally_granted_group_permcodes +
+                                                  per_forum_granted_group_permcodes)
 
                     # Includes the permissions granted for the user' groups in the initial set of
                     # permission codenames.
-                    perms |= granted_group_perms
-
-            self._forum_perms_cache[forum.id] = perms
+                    permcodes |= granted_group_permcodes
+            self._forum_perms_cache[forum.id] = permcodes
 
         return self._forum_perms_cache[forum.id]


### PR DESCRIPTION
This PR fixes the issue #163.
It first adds tests for the 4 possible combinations that gave 2 unexpected results:
```
	|	Group	| 	User	|	Result	| 	Expected|
=========================================================================
Global	|	Yes	|	No	|	Yes	|	No	|
Global	|	No	|	Yes	|	Yes	|		|
Forum	|	Yes	|	No	|	No	|		|
Forum	|	No	|	Yes	|	No	|	Yes	|

```
Then it adds fixes to get the results to be as expected.