### PR TITLE
Observe admin permissions on forum permissions

### DIFF
--- a/machina/apps/forum/admin.py
+++ b/machina/apps/forum/admin.py
@@ -194,12 +194,22 @@ class ForumAdmin(admin.ModelAdmin):
         elif forum:
             context['forum_form'] = PickForumForm()
 
+        show_user_perm_form = (request.user.has_perm('forum_permission.add_userforumpermission') or
+                               request.user.has_perm('forum_permission.change_userforumpermission'))
+        show_grp_perm_form = (request.user.has_perm('forum_permission.add_groupforumpermission') or
+                              request.user.has_perm('forum_permission.change_groupforumpermission'))
+        user_form, user = None, None
+        group_form, group = None, None
+
         # Handles user or group selection
         if request.method == 'POST' and not permissions_copied:
-            user_form = PickUserForm(request.POST, admin_site=self.admin_site)
-            group_form = PickGroupForm(request.POST, admin_site=self.admin_site)
+            if show_user_perm_form:
+                user_form = PickUserForm(request.POST, admin_site=self.admin_site)
+            if show_grp_perm_form:
+                group_form = PickGroupForm(request.POST, admin_site=self.admin_site)
 
-            if user_form.is_valid() and group_form.is_valid():
+            # Check if the form was drawn, was valid and was submitted (presence of submitbutton)
+            if user_form and user_form.is_valid() and '_select_user' in request.POST:
                 user = user_form.cleaned_data.get('user', None) if user_form.cleaned_data else None
                 anonymous_user = (
                     user_form.cleaned_data.get('anonymous_user', None)
@@ -209,16 +219,11 @@ class ForumAdmin(admin.ModelAdmin):
                     user_form.cleaned_data.get('authenticated_user', None)
                     if user_form.cleaned_data else None
                 )
-                group = (
-                    group_form.cleaned_data.get('group', None)
-                    if group_form.cleaned_data else None
-                )
 
-                if not user and not anonymous_user and not authenticated_user and not group:
+                if not user and not anonymous_user and not authenticated_user:
                     user_form._errors[NON_FIELD_ERRORS] = user_form.error_class([
                         _(
-                            "Choose either a user ID, a group ID, the anonymous user " +
-                            "or the authenticated user"
+                            "Choose either a user ID, the anonymous user or the authenticated user"
                         ),
                     ])
                 elif user:
@@ -248,7 +253,18 @@ class ForumAdmin(admin.ModelAdmin):
                             kwargs=url_kwargs,
                         ),
                     )
-                elif group:
+
+                context['user_errors'] = helpers.AdminErrorList(user_form, [])
+
+            # Check if the form was drawn, was valid and was submitted (presence of submitbutton)
+            if group_form and group_form.is_valid() and '_select_group' in request.POST:
+                group = group_form.cleaned_data.get('group', None) \
+                    if group_form.cleaned_data else None
+
+                if not group:
+                    group_form._errors[NON_FIELD_ERRORS] = group_form.error_class(
+                        [_('Choose a group ID'), ])
+                else:
                     # Redirect to group
                     url_kwargs = (
                         {'forum_id': forum.id, 'group_id': group.id}
@@ -258,11 +274,12 @@ class ForumAdmin(admin.ModelAdmin):
                         reverse('admin:forum_forum_editpermission_group', kwargs=url_kwargs),
                     )
 
-            context['user_errors'] = helpers.AdminErrorList(user_form, [])
             context['group_errors'] = helpers.AdminErrorList(group_form, [])
         else:
-            user_form = PickUserForm(admin_site=self.admin_site)
-            group_form = PickGroupForm(admin_site=self.admin_site)
+            if show_user_perm_form:
+                user_form = PickUserForm(admin_site=self.admin_site)
+            if show_grp_perm_form:
+                group_form = PickGroupForm(admin_site=self.admin_site)
 
         context['user_form'] = user_form
         context['group_form'] = group_form

--- a/machina/templates/admin/forum/forum/editpermissions_index.html
+++ b/machina/templates/admin/forum/forum/editpermissions_index.html
@@ -21,66 +21,76 @@
 {% endif %}
 
 {% block content %}
-<form action="." method="post" id="{{ opts.model_name }}_pick_user_form" novalidate>{% csrf_token %}
-  <div>
-    {% if user_errors %}
-    <p class="errornote">
-    {% if user_errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
-    </p>
-    {{ user_form.non_field_errors }}
-    {% endif %}
-    <fieldset class="module aligned {{ fieldset.classes }}">
-      <h2>{% trans "Edit user permissions" %}</h2>
-      <div class="description">{% trans "Please select a user in order to update its permissions" %}</div>
-      {% for field in user_form %}
-      <div class="form-row">
-        <div {% if field.is_checkbox %} class="checkbox-row"{% else %} class="field-box field-{{ field.name }}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.is_hidden %} hidden{% endif %}"{% endif %}>
-          {% if not field.is_readonly %}{{ field.errors }}{% endif %}
-          {% if field.is_checkbox %}
-          {{ field.field }}{{ field.label_tag }}
-          {% else %}
-          {{ field.label_tag }}
-          {{ field }}
-          {% endif %}
-          {% if field.field.help_text %}
-          <p class="help">{{ field.field.help_text|safe }}</p>
-          {% endif %}
-        </div>
+  {% if user_form %}
+    <form action="." method="post" id="{{ opts.model_name }}_pick_user_form" novalidate>{% csrf_token %}
+      <div>
+        {% if user_errors %}
+        <p class="errornote">
+        {% if user_errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
+        </p>
+        {{ user_form.non_field_errors }}
+        {% endif %}
+        <fieldset class="module aligned {{ fieldset.classes }}">
+          <h2>{% trans "Edit user permissions" %}</h2>
+          <div class="description">{% trans "Please select a user in order to update its permissions" %}</div>
+          {% for field in user_form %}
+          <div class="form-row">
+            <div {% if field.is_checkbox %} class="checkbox-row"{% else %} class="field-box field-{{ field.name }}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.is_hidden %} hidden{% endif %}"{% endif %}>
+              {% if not field.is_readonly %}{{ field.errors }}{% endif %}
+              {% if field.is_checkbox %}
+              {{ field.field }}{{ field.label_tag }}
+              {% else %}
+              {{ field.label_tag }}
+              {{ field }}
+              {% endif %}
+              {% if field.field.help_text %}
+              <p class="help">{{ field.field.help_text|safe }}</p>
+              {% endif %}
+            </div>
+          </div>
+          {% endfor %}
+        </fieldset>
       </div>
-      {% endfor %}
-    </fieldset>
-  </div>
-  <div class="submit-row">
-    <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_user" />
-  </div>
-</form>
-<form action="." method="post" id="{{ opts.model_name }}_pick_group_form" novalidate>{% csrf_token %}
-  <div>
-    <fieldset class="module aligned {{ fieldset.classes }}">
-      <h2>{% trans "Edit group permissions" %}</h2>
-      <div class="description">{% trans "Please select a group in order to update its permissions" %}</div>
-      {% for field in group_form %}
-      <div class="form-row">
-        <div {% if field.is_checkbox %} class="checkbox-row"{% else %} class="field-box field-{{ field.name }}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.is_hidden %} hidden{% endif %}"{% endif %}>
-          {% if not field.is_readonly %}{{ field.errors }}{% endif %}
-          {% if field.is_checkbox %}
-          {{ field.field }}{{ field.label_tag }}
-          {% else %}
-          {{ field.label_tag }}
-          {{ field }}
-          {% endif %}
-          {% if field.field.help_text %}
-          <p class="help">{{ field.field.help_text|safe }}</p>
-          {% endif %}
-        </div>
+      <div class="submit-row">
+        <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_user" />
       </div>
-      {% endfor %}
-    </fieldset>
-  </div>
-  <div class="submit-row">
-    <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_group" />
-  </div>
-</form>
+    </form>
+  {% endif %}
+  {% if group_form %}
+    <form action="." method="post" id="{{ opts.model_name }}_pick_group_form" novalidate>{% csrf_token %}
+      <div>
+        {% if group_errors %}
+          <p class="errornote">
+            {% if group_errors|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
+          </p>
+          {{ group_form.non_field_errors }}
+        {% endif %}
+        <fieldset class="module aligned {{ fieldset.classes }}">
+          <h2>{% trans "Edit group permissions" %}</h2>
+          <div class="description">{% trans "Please select a group in order to update its permissions" %}</div>
+          {% for field in group_form %}
+          <div class="form-row">
+            <div {% if field.is_checkbox %} class="checkbox-row"{% else %} class="field-box field-{{ field.name }}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.is_hidden %} hidden{% endif %}"{% endif %}>
+              {% if not field.is_readonly %}{{ field.errors }}{% endif %}
+              {% if field.is_checkbox %}
+              {{ field.field }}{{ field.label_tag }}
+              {% else %}
+              {{ field.label_tag }}
+              {{ field }}
+              {% endif %}
+              {% if field.field.help_text %}
+              <p class="help">{{ field.field.help_text|safe }}</p>
+              {% endif %}
+            </div>
+          </div>
+          {% endfor %}
+        </fieldset>
+      </div>
+      <div class="submit-row">
+        <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_group" />
+      </div>
+    </form>
+  {% endif %}
 {% if forum %}
 <form action="." method="post" id="{{ opts.model_name }}_pick_forum_form" novalidate>{% csrf_token %}
   <div>

--- a/tests/functional/apps/forum/test_admin.py
+++ b/tests/functional/apps/forum/test_admin.py
@@ -102,6 +102,19 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
         assert response.status_code == 200
         assert response.context['user_form'].errors is not None
 
+    def test_editpermission_index_view_gives_error_without_user(self):
+        # Setup
+        model = self.model
+        raw_url = 'admin:{}_{}_editpermission_index'.format(
+            model._meta.app_label, self._get_module_name(model._meta))
+        # Run, ommitting user id
+        url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
+        response = self.client.post(url, {'_select_user': True}, follow=True)
+
+        # We should get a response to the same page (we're not redirected further)
+        # But an error should have been set because of a missing user id
+        assert len(response.context['user_errors']) > 0
+
     def test_editpermission_index_view_can_redirect_to_user_permissions_form(self):
         # Setup
         model = self.model
@@ -171,6 +184,19 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
         assert len(response.redirect_chain)
         last_url, status_code = response.redirect_chain[-1]
         assert editpermissions_group_url in last_url
+
+    def test_editpermission_index_view_gives_error_without_group(self):
+        # Setup
+        model = self.model
+        raw_url = 'admin:{}_{}_editpermission_index'.format(
+            model._meta.app_label, self._get_module_name(model._meta))
+        # Run, ommitting group import ipdb; ipdb.set_trace()
+        url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
+        response = self.client.post(url, {'_select_group': True}, follow=True)
+
+        # We should get a response to the same page (we're not redirected further)
+        # But an error should have been set because of the missing group id
+        assert len(response.context['group_errors']) > 0
 
     def test_editpermission_index_view_can_copy_permissions_from_another_forum(self):
         # Setup

--- a/tests/functional/apps/forum/test_admin.py
+++ b/tests/functional/apps/forum/test_admin.py
@@ -122,7 +122,7 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
             model._meta.app_label, self._get_module_name(model._meta))
         # Run
         url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
-        response = self.client.post(url, {'user': self.user.id}, follow=True)
+        response = self.client.post(url, {'user': self.user.id, '_select_user': True}, follow=True)
         # Check
         editpermissions_user_raw_url = 'admin:{}_{}_editpermission_user'.format(
             model._meta.app_label, self._get_module_name(model._meta))
@@ -139,7 +139,7 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
             model._meta.app_label, self._get_module_name(model._meta))
         # Run
         url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
-        response = self.client.post(url, {'anonymous_user': 1}, follow=True)
+        response = self.client.post(url, {'anonymous_user': 1, '_select_user': True}, follow=True)
         # Check
         editpermissions_anonymous_user_raw_url = 'admin:{}_{}_editpermission_anonymous_user'.format(
             model._meta.app_label, self._get_module_name(model._meta))
@@ -156,7 +156,11 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
             model._meta.app_label, self._get_module_name(model._meta))
         # Run
         url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
-        response = self.client.post(url, {'authenticated_user': 1}, follow=True)
+        response = self.client.post(
+            url,
+            {'authenticated_user': 1, '_select_user': True},
+            follow=True
+        )
         # Check
         editpermissions_auth_user_raw_url = ('admin:{}_{}_editpermission_authenticated_user'
                                              .format(model._meta.app_label,
@@ -175,7 +179,7 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
             model._meta.app_label, self._get_module_name(model._meta))
         # Run
         url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
-        response = self.client.post(url, {'group': group.id}, follow=True)
+        response = self.client.post(url, {'group': group.id, '_select_group': True}, follow=True)
         # Check
         editpermissions_group_raw_url = 'admin:{}_{}_editpermission_group'.format(
             model._meta.app_label, self._get_module_name(model._meta))


### PR DESCRIPTION
This PR fixes the problem in the first paragraph of [issue 126](https://github.com/ellmetha/django-machina/issues/126): making sure that if a user has no right to edit grouppermissions or userpermissions on a forum he is not shown the interface when approaching the permissions via the forum app. 

The apps were already correctly hidden from the admin index but were still available when going via the forum tree. This is now fixed.