### PR TITLE
Show users and groups that already have permissions on a forum

### DIFF
--- a/machina/apps/forum/admin.py
+++ b/machina/apps/forum/admin.py
@@ -284,8 +284,24 @@ class ForumAdmin(admin.ModelAdmin):
         else:
             if can_change_user_perms:
                 user_form = PickUserForm(admin_site=self.admin_site)
+                user_perms = (
+                    UserForumPermission.objects.filter(
+                        forum=forum
+                    )
+                    .values('user__first_name', 'user__last_name', 'user__id')
+                    .distinct()
+                )
+                context['users_with_perms'] = user_perms
             if can_change_group_perms:
                 group_form = PickGroupForm(admin_site=self.admin_site)
+                group_perms = (
+                    GroupForumPermission.objects.filter(
+                        forum=forum
+                    )
+                    .values('group__name', 'group__id')
+                    .distinct()
+                )
+                context['groups_with_perms'] = group_perms
 
         context['user_form'] = user_form
         context['group_form'] = group_form

--- a/machina/apps/forum/admin.py
+++ b/machina/apps/forum/admin.py
@@ -127,6 +127,11 @@ class ForumAdmin(admin.ModelAdmin):
                 name='forum_forum_editpermission_group',
             ),
             url(
+                r'^view-permission-holders/$',
+                self.admin_site.admin_view(self.view_permission_holders_view),
+                name='forum_forum_view_permission_holders',
+            ),
+            url(
                 r'^(?P<forum_id>[0-9]+)/view-permission-holders/$',
                 self.admin_site.admin_view(self.view_permission_holders_view),
                 name='forum_forum_view_permission_holders',
@@ -186,7 +191,13 @@ class ForumAdmin(admin.ModelAdmin):
         # Set up the context
         context = self.get_forum_perms_base_context(request, forum)
         context['forum'] = forum
-        context['title'] = _('Forum permissions') if forum else _('Global forum permissions')
+        if forum:
+            context['title'] = _('Forum permissions')
+            context['linkurl'] = reverse('admin:forum_forum_view_permission_holders',
+                                         kwargs={'forum_id': forum.id})
+        else:
+            context['title'] = _('Global forum permissions')
+            context['linkurl'] = reverse('admin:forum_forum_view_permission_holders')
 
         can_change_user_perms = (
             request.user.has_perm('forum_permission.add_userforumpermission') or

--- a/machina/templates/admin/forum/forum/editpermissions_index.html
+++ b/machina/templates/admin/forum/forum/editpermissions_index.html
@@ -54,9 +54,13 @@
       <div>
         {% if users_with_perms %}
           <h3>
-            {% blocktrans %}
-            Users (name and id) that already have permissions for forum '{{forum.name}}'
-            {% endblocktrans %}
+            {% if forum.name %}
+              {% blocktrans %}
+              Users (name and id) that already have permissions for forum '{{forum.name}}'
+              {% endblocktrans %}
+            {% else %}
+              {%trans 'Users (name and id) that already have global permissions' %}
+            {% endif %}
           </h3>
           <ul>
           {% for u in users_with_perms %}
@@ -103,9 +107,13 @@
       <div>
         {% if groups_with_perms %}
         <h3>
-          {% blocktrans %}
-          Groups (name and id) that already have permissions for forum '{{forum.name}}'
-          {% endblocktrans %}
+          {% if forum.name %}
+            {% blocktrans %}
+            Groups (name and id) that already have permissions for forum '{{forum.name}}'
+            {% endblocktrans %}
+          {% else %}
+            {%trans 'Groups (name and id) that already have global permissions' %}
+          {% endif %}
         </h3>
           <ul>
           {% for g in groups_with_perms %}

--- a/machina/templates/admin/forum/forum/editpermissions_index.html
+++ b/machina/templates/admin/forum/forum/editpermissions_index.html
@@ -64,7 +64,7 @@
           </h3>
           <ul>
           {% for u in users_with_perms %}
-            <li>{{u.user__first_name}} {{u.user__last_name}} ({{ u.user__id}})</li>
+            <li>{{u}}</li>
           {% endfor %}
           </ul>
         {% endif %}

--- a/machina/templates/admin/forum/forum/editpermissions_index.html
+++ b/machina/templates/admin/forum/forum/editpermissions_index.html
@@ -52,22 +52,7 @@
         </fieldset>
       </div>
       <div>
-        {% if users_with_perms %}
-          <h3>
-            {% if forum.name %}
-              {% blocktrans %}
-              Users (name and id) that already have permissions for forum '{{forum.name}}'
-              {% endblocktrans %}
-            {% else %}
-              {%trans 'Users (name and id) that already have global permissions' %}
-            {% endif %}
-          </h3>
-          <ul>
-          {% for u in users_with_perms %}
-            <li>{{u}}</li>
-          {% endfor %}
-          </ul>
-        {% endif %}
+        <a class="custom-popup" href="{% url 'admin:forum_forum_view_permission_holders' forum.id %}">{% trans 'See users with permissions' %}</a>
       </div>
       <div class="submit-row">
         <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_user" />
@@ -105,22 +90,7 @@
         </fieldset>
       </div>
       <div>
-        {% if groups_with_perms %}
-        <h3>
-          {% if forum.name %}
-            {% blocktrans %}
-            Groups (name and id) that already have permissions for forum '{{forum.name}}'
-            {% endblocktrans %}
-          {% else %}
-            {%trans 'Groups (name and id) that already have global permissions' %}
-          {% endif %}
-        </h3>
-          <ul>
-          {% for g in groups_with_perms %}
-            <li>{{g.group__name}} ({{ g.group__id}})</li>
-          {% endfor %}
-          </ul>
-        {% endif %}
+        <a class="custom-popup" href="{% url 'admin:forum_forum_view_permission_holders' forum.id %}">{% trans 'See groups with permissions' %}</a>
       </div>
       <div class="submit-row">
         <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_group" />
@@ -167,6 +137,12 @@
         if (!event.isDefaultPrevented()) {
           showRelatedObjectLookupPopup(this);
         }
+      });
+      $('.custom-popup').click(function(e) {
+        e.preventDefault();
+        href = $(this).attr('href') + '?_popup=1'
+        var win = window.open(href, 'Permissions', 'height=500,width=600,resizable=yes,scrollbars=yes');
+        win.focus();
       });
     });
   })(django.jQuery);

--- a/machina/templates/admin/forum/forum/editpermissions_index.html
+++ b/machina/templates/admin/forum/forum/editpermissions_index.html
@@ -51,6 +51,20 @@
           {% endfor %}
         </fieldset>
       </div>
+      <div>
+        {% if users_with_perms %}
+          <h3>
+            {% blocktrans %}
+            Users (name and id) that already have permissions for forum '{{forum.name}}'
+            {% endblocktrans %}
+          </h3>
+          <ul>
+          {% for u in users_with_perms %}
+            <li>{{u.user__first_name}} {{u.user__last_name}} ({{ u.user__id}})</li>
+          {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
       <div class="submit-row">
         <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_user" />
       </div>
@@ -85,6 +99,20 @@
           </div>
           {% endfor %}
         </fieldset>
+      </div>
+      <div>
+        {% if groups_with_perms %}
+        <h3>
+          {% blocktrans %}
+          Groups (name and id) that already have permissions for forum '{{forum.name}}'
+          {% endblocktrans %}
+        </h3>
+          <ul>
+          {% for g in groups_with_perms %}
+            <li>{{g.group__name}} ({{ g.group__id}})</li>
+          {% endfor %}
+          </ul>
+        {% endif %}
       </div>
       <div class="submit-row">
         <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_group" />

--- a/machina/templates/admin/forum/forum/editpermissions_index.html
+++ b/machina/templates/admin/forum/forum/editpermissions_index.html
@@ -52,7 +52,7 @@
         </fieldset>
       </div>
       <div>
-        <a class="custom-popup" href="{% url 'admin:forum_forum_view_permission_holders' forum.id %}">{% trans 'See users with permissions' %}</a>
+        <a class="custom-popup" href="{{ linkurl }}">{% trans 'See users with permissions' %}</a>
       </div>
       <div class="submit-row">
         <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_user" />
@@ -90,7 +90,7 @@
         </fieldset>
       </div>
       <div>
-        <a class="custom-popup" href="{% url 'admin:forum_forum_view_permission_holders' forum.id %}">{% trans 'See groups with permissions' %}</a>
+        <a class="custom-popup" href="{{ linkurl }}">{% trans 'See groups with permissions' %}</a>
       </div>
       <div class="submit-row">
         <input type="submit" value="{% trans 'Select' %}" class="default" name="_select_group" />

--- a/machina/templates/admin/forum/forum/view_permission_holders.html
+++ b/machina/templates/admin/forum/forum/view_permission_holders.html
@@ -1,0 +1,44 @@
+{% extends "admin/base_site.html" %}
+{% load admin_modify %}
+{% load admin_urls %}
+{% load i18n%}
+{% load static %}
+
+{% block coltype %}colM{% endblock %}
+
+{% block content %}
+    {% if users_with_perms %}
+      <h3>
+        {% if forum.name %}
+          {% blocktrans with forum.name as forumname %}
+          Users (name and id) that already have permissions for forum '{{forumname}}'
+          {% endblocktrans %}
+        {% else %}
+          {%trans 'Users (name and id) that already have global permissions' %}
+        {% endif %}
+      </h3>
+      <ul>
+      {% for u in users_with_perms %}
+        <li>{{u}}</li>
+      {% endfor %}
+      </ul>
+    {% endif %}
+
+    {% if groups_with_perms %}
+    <h3>
+      {% if forum.name %}
+        {% blocktrans with forum.name as forumname %}
+        Groups (name and id) that already have permissions for forum '{{forumname}}'
+        {% endblocktrans %}
+      {% else %}
+        {%trans 'Groups (name and id) that already have global permissions' %}
+      {% endif %}
+    </h3>
+      <ul>
+      {% for g in groups_with_perms %}
+        <li>{{g.group__name}} ({{ g.group__id}})</li>
+      {% endfor %}
+      </ul>
+    {% endif %}
+
+{% endblock content %}

--- a/tests/functional/apps/forum/test_admin.py
+++ b/tests/functional/apps/forum/test_admin.py
@@ -85,6 +85,28 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
         model = self.model
         raw_url = 'admin:{}_{}_editpermission_index'.format(
             model._meta.app_label, self._get_module_name(model._meta))
+
+        # These permissions are not explicitely tested or checked but should result
+        # in a list of users and groups that already have permissions, so they affect the view
+        # that we are testing here.
+        group = GroupFactory.create()
+        UserForumPermissionFactory.create(
+            permission=ForumPermission.objects.get(codename='can_see_forum'),
+            forum=self.top_level_cat,
+            user=self.user, has_perm=True)
+        UserForumPermissionFactory.create(
+            permission=ForumPermission.objects.get(codename='can_read_forum'),
+            forum=self.top_level_cat,
+            anonymous_user=True, has_perm=True)
+        UserForumPermissionFactory.create(
+            permission=ForumPermission.objects.get(codename='can_start_new_topics'),
+            forum=self.top_level_cat,
+            authenticated_user=True, has_perm=True)
+        GroupForumPermissionFactory.create(
+            permission=ForumPermission.objects.get(codename='can_start_new_topics'),
+            forum=self.sub_forum_1,
+            group=group, has_perm=False)
+
         # Run
         url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
         response = self.client.get(url)

--- a/tests/functional/apps/forum/test_admin.py
+++ b/tests/functional/apps/forum/test_admin.py
@@ -86,6 +86,21 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
         raw_url = 'admin:{}_{}_editpermission_index'.format(
             model._meta.app_label, self._get_module_name(model._meta))
 
+        # Run
+        url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
+        response = self.client.get(url)
+        global_url = reverse(raw_url)  # Working on global rights
+        global_response = self.client.get(global_url)
+        # Check
+        assert response.status_code == 200
+        assert global_response.status_code == 200
+
+    def test_permission_holders_view(self):
+        # Setup
+        model = self.model
+        raw_url = 'admin:{}_{}_view_permission_holders'.format(
+            model._meta.app_label, self._get_module_name(model._meta))
+
         # These permissions are not explicitely tested or checked but should result
         # in a list of users and groups that already have permissions, so they affect the view
         # that we are testing here.
@@ -110,8 +125,11 @@ class TestForumAdmin(AdminClientTestCase, AdminBaseViewTestMixin):
         # Run
         url = reverse(raw_url, kwargs={'forum_id': self.top_level_cat.id})
         response = self.client.get(url)
+        global_url = reverse(raw_url)  # Working on global rights
+        global_response = self.client.get(global_url)
         # Check
         assert response.status_code == 200
+        assert global_response.status_code == 200
 
     def test_editpermission_index_view_submission_cannot_work_without_data(self):
         # Setup


### PR DESCRIPTION
In the index page of permissions for a specific forum (choosing which group/user
to go edit the permissions for) show (in text) which users and groups already
have permissions set for this forum.
This makes is easier to select a user/group to edit existing permissions for
and it also reminds the admin user which users/groups he has already made
permissions for for the chosen forum.