### PR TITLE
Remove warning deprecated django methods

### DIFF
--- a/machina/apps/forum/admin.py
+++ b/machina/apps/forum/admin.py
@@ -8,7 +8,7 @@
 
 from collections import OrderedDict
 
-from django.conf.urls import url
+from django.conf.urls import re_path
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.auth import get_user_model
@@ -70,57 +70,57 @@ class ForumAdmin(admin.ModelAdmin):
         """ Returns the URLs associated with the admin abstraction. """
         urls = super().get_urls()
         forum_admin_urls = [
-            url(
+            re_path(
                 r'^(?P<forum_id>[0-9]+)/move-forum/(?P<direction>up|down)/$',
                 self.admin_site.admin_view(self.moveforum_view),
                 name='forum_forum_move',
             ),
-            url(
+            re_path(
                 r'^edit-global-permissions/$',
                 self.admin_site.admin_view(self.editpermissions_index_view),
                 name='forum_forum_editpermission_index',
             ),
-            url(
+            re_path(
                 r'^edit-global-permissions/user/(?P<user_id>[0-9]+)/$',
                 self.admin_site.admin_view(self.editpermissions_user_view),
                 name='forum_forum_editpermission_user',
             ),
-            url(
+            re_path(
                 r'^edit-global-permissions/user/anonymous/$',
                 self.admin_site.admin_view(self.editpermissions_anonymous_user_view),
                 name='forum_forum_editpermission_anonymous_user',
             ),
-            url(
+            re_path(
                 r'^edit-global-permissions/user/authenticated/$',
                 self.admin_site.admin_view(self.editpermissions_authenticated_user_view),
                 name='forum_forum_editpermission_authenticated_user',
             ),
-            url(
+            re_path(
                 r'^edit-global-permissions/group/(?P<group_id>[0-9]+)/$',
                 self.admin_site.admin_view(self.editpermissions_group_view),
                 name='forum_forum_editpermission_group',
             ),
-            url(
+            re_path(
                 r'^(?P<forum_id>[0-9]+)/edit-permissions/$',
                 self.admin_site.admin_view(self.editpermissions_index_view),
                 name='forum_forum_editpermission_index',
             ),
-            url(
+            re_path(
                 r'^(?P<forum_id>[0-9]+)/edit-permissions/user/(?P<user_id>[0-9]+)/$',
                 self.admin_site.admin_view(self.editpermissions_user_view),
                 name='forum_forum_editpermission_user',
             ),
-            url(
+            re_path(
                 r'^(?P<forum_id>[0-9]+)/edit-permissions/user/anonymous/$',
                 self.admin_site.admin_view(self.editpermissions_anonymous_user_view),
                 name='forum_forum_editpermission_anonymous_user',
             ),
-            url(
+            re_path(
                 r'^(?P<forum_id>[0-9]+)/edit-permissions/user/authenticated/$',
                 self.admin_site.admin_view(self.editpermissions_authenticated_user_view),
                 name='forum_forum_editpermission_authenticated_user',
             ),
-            url(
+            re_path(
                 r'^(?P<forum_id>[0-9]+)/edit-permissions/group/(?P<group_id>[0-9]+)/$',
                 self.admin_site.admin_view(self.editpermissions_group_view),
                 name='forum_forum_editpermission_group',

--- a/machina/apps/forum/signals.py
+++ b/machina/apps/forum/signals.py
@@ -8,7 +8,8 @@
 
 import django.dispatch
 
-# Arguments: "previous_parent"
-forum_moved = django.dispatch.Signal()
-# Arguments: "forum", "user", "request", "response"
-forum_viewed = django.dispatch.Signal()
+
+# Arguments:"previous_parent"
+forum_moved = django.dispatch.Signal(providing_args=["previous_parent", ])
+# Arguments:"forum", "user", "request", "response"
+forum_viewed = django.dispatch.Signal(providing_args=["forum", "user", "request", "response", ])

--- a/machina/apps/forum/signals.py
+++ b/machina/apps/forum/signals.py
@@ -8,6 +8,7 @@
 
 import django.dispatch
 
-
-forum_moved = django.dispatch.Signal(providing_args=["previous_parent", ])
-forum_viewed = django.dispatch.Signal(providing_args=["forum", "user", "request", "response", ])
+# Arguments: "previous_parent"
+forum_moved = django.dispatch.Signal()
+# Arguments: "forum", "user", "request", "response"
+forum_viewed = django.dispatch.Signal()

--- a/machina/apps/forum_conversation/signals.py
+++ b/machina/apps/forum_conversation/signals.py
@@ -8,5 +8,5 @@
 
 import django.dispatch
 
-
-topic_viewed = django.dispatch.Signal(providing_args=["topic", "user", "request", "response", ])
+# Arguments: "topic",  "user", "request", "response"
+topic_viewed = django.dispatch.Signal()

--- a/machina/apps/forum_conversation/signals.py
+++ b/machina/apps/forum_conversation/signals.py
@@ -8,5 +8,6 @@
 
 import django.dispatch
 
-# Arguments: "topic",  "user", "request", "response"
+
+# "topic", "user", "request", "response"
 topic_viewed = django.dispatch.Signal()

--- a/machina/urls.py
+++ b/machina/urls.py
@@ -6,7 +6,7 @@
 
 """
 
-from django.conf.urls import include, url
+from django.conf.urls import include, re_path
 
 from machina.core.loading import get_class
 from machina.core.urls import URLPatternsFactory
@@ -26,13 +26,13 @@ class BoardURLPatternsFactory(URLPatternsFactory):
     def get_urlpatterns(self):
         """ Returns the URL patterns managed by the considered factory / application. """
         return [
-            url(r'', include(self.forum_urlpatterns_factory.urlpatterns)),
-            url(r'', include(self.conversation_urlpatterns_factory.urlpatterns)),
-            url(r'^feeds/', include(self.feeds_urlpatterns_factory.urlpatterns)),
-            url(r'^member/', include(self.member_urlpatterns_factory.urlpatterns)),
-            url(r'^moderation/', include(self.moderation_urlpatterns_factory.urlpatterns)),
-            url(r'^search/', include(self.search_urlpatterns_factory.urlpatterns)),
-            url(r'^tracking/', include(self.tracking_urlpatterns_factory.urlpatterns)),
+            re_path(r'', include(self.forum_urlpatterns_factory.urlpatterns)),
+            re_path(r'', include(self.conversation_urlpatterns_factory.urlpatterns)),
+            re_path(r'^feeds/', include(self.feeds_urlpatterns_factory.urlpatterns)),
+            re_path(r'^member/', include(self.member_urlpatterns_factory.urlpatterns)),
+            re_path(r'^moderation/', include(self.moderation_urlpatterns_factory.urlpatterns)),
+            re_path(r'^search/', include(self.search_urlpatterns_factory.urlpatterns)),
+            re_path(r'^tracking/', include(self.tracking_urlpatterns_factory.urlpatterns)),
         ]
 
 


### PR DESCRIPTION
### Purpose

Django 3.1 version have introduced deprecated method
- The purely documentational providing_args argument for Signal is deprecated. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
- django.conf.urls.url() is deprecated in favor of django.urls.re_path()

### Proposal
Update the code to follow new recommendations, check that this code is compatible with django 2.2x as it's supported by django-machina

- https://docs.djangoproject.com/en/2.2/ref/urls/  => re_path supported in django 2.2
- https://docs.djangoproject.com/en/2.2/topics/signals/ indicates that providing_args is purely documentational
