### PR TITLE
Fix #262 - Disable pre_save receivers during loaddata of fixtures

### DIFF
--- a/machina/apps/forum_member/receivers.py
+++ b/machina/apps/forum_member/receivers.py
@@ -29,6 +29,10 @@ def increase_posts_count(sender, instance, **kwargs):
     forum post being created or updated.
     """
 
+    if kwargs.get('raw'):
+        # do nothing, when loading data (fixtures)
+        return
+
     if instance.poster is None:
         # An anonymous post is considered. No profile can be updated in
         # that case.
@@ -61,6 +65,11 @@ def decrease_posts_count_after_post_unaproval(sender, instance, **kwargs):
     This receiver handles the unaproval of a forum post: the posts count associated with the post's
     author is decreased.
     """
+
+    if kwargs.get('raw'):
+        # do nothing, when loading data (fixtures)
+        return
+
     if not instance.pk or not instance.poster:
         # Do not consider posts being created or posts of anonymous users
         return


### PR DESCRIPTION
This pull request fixes #262 by disabling the `pre_save` receiver functions during the execution of `./manage.py loaddata some-fixture.json`.

Regarding the rules (https://django-machina.readthedocs.org/en/stable/contributing.html):
- make qa does not return anything for my changes
- make tests succeeds
- make coverage shows that the coverage of `machina/apps/forum_member/receivers.py` is reduced to 96% (from 100%):
  `machina/apps/forum_member/receivers.py                                    52      2    96%   34, 71`
  but I think, this is acceptable because the lines 34 and 71 only contain a `return` statement.
