### PR TITLE
make sure there is no new line in subject

### DIFF
--- a/machina/test/factories/conversation.py
+++ b/machina/test/factories/conversation.py
@@ -29,7 +29,7 @@ class TopicFactory(factory.django.DjangoModelFactory):
 class PostFactory(factory.django.DjangoModelFactory):
     topic = factory.SubFactory(TopicFactory)
     poster = factory.SubFactory(UserFactory)
-    subject = factory.LazyAttribute(lambda t: faker.text(max_nb_chars=200))
+    subject = factory.LazyAttribute(lambda t: faker.sentence()[:200])
     content = fuzzy.FuzzyText(length=255)
 
     class Meta:


### PR DESCRIPTION
In my application where I use `make_topic` to create a topic and sent the topic via email, I got complaints that `topic.subject` contains new line.

Since `topic.subject` is not supposed to contain newline, this patch changes `faker.text` to `taker.sentence`.