### PR TITLE
Fixed a Typo in the Documentation

### DIFF
--- a/docs/customization/overriding_applications.rst
+++ b/docs/customization/overriding_applications.rst
@@ -128,11 +128,11 @@ Add the local application to your INSTALLED_APPS
 
 Finally you have to tell Django to use your overridden application instead of the django-machina's
 original application. You can do this by replacing the machina's original application in the
-``INSTALLED_APS`` setting by the application you just created:
+``INSTALLED_APPS`` setting by the application you just created:
 
 .. code-block:: python
 
-  INSTALLED_APS = (
+  INSTALLED_APPS = (
       'django.contrib.auth',
       'django.contrib.contenttypes',
       'django.contrib.sessions',

--- a/docs/customization/recipes/using_another_markup_language.rst
+++ b/docs/customization/recipes/using_another_markup_language.rst
@@ -25,7 +25,7 @@ The first thing to do is to add ``ckeditor`` in our ``INSTALLED_APPS`` setting:
 
 .. code-block:: python
 
-  INSTALLED_APS = (
+  INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -45,7 +45,7 @@ includes the machina's dependencies and the machina's own applications as follow
 
 .. code-block:: python
 
-    INSTALLED_APS = (
+    INSTALLED_APPS = (
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.sessions',


### PR DESCRIPTION
I fixed instances of a typo of "INSTALLED_APS" instead of "INSTALLED_APPS" in the documentation.